### PR TITLE
fix: fix compiler error

### DIFF
--- a/subgraphs/venus/src/mappings/helpers.ts
+++ b/subgraphs/venus/src/mappings/helpers.ts
@@ -16,13 +16,14 @@ import { updateMarket } from './markets';
 
 const comptrollerAddress = Address.fromString('0xfd36e2c2a6789db23113685031d7f16329158384');
 
-export const exponentToBigDecimal = (decimals: i32): BigDecimal => {
+// Writting this as an arrow function, produces a type signature compile error
+export function exponentToBigDecimal(decimals: i32): BigDecimal {
   let bd = BigDecimal.fromString('1');
   for (let i = 0; i < decimals; i++) {
     bd = bd.times(BigDecimal.fromString('10'));
   }
   return bd;
-};
+}
 
 export let mantissaFactor = 18;
 export let vTokenDecimals = 8;


### PR DESCRIPTION
Writing this function as an arrow function causes a complier error where the type is incorrect. Writing it with a function declaration doesn't have this error