### PR TITLE
Remove create commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
   "scripts": {
     "codegen": "yarn workspaces foreach run codegen",
     "create:local": "yarn workspaces foreach run create:local",
-    "create:testnet": "yarn workspaces foreach run create:testnet",
-    "create:mainnet": "yarn workspaces foreach run create:mainnet",
     "build:local": "yarn workspaces foreach run build:local",
     "build:testnet": "yarn workspaces foreach run build:testnet",
     "build:mainnet": "yarn workspaces foreach run build:mainnet",

--- a/subgraphs/isolated-pools/package.json
+++ b/subgraphs/isolated-pools/package.json
@@ -12,8 +12,6 @@
   "scripts": {
     "codegen": "graph codegen",
     "create:local": "graph create venusprotocol/venus-isolated-pools --node http://127.0.0.1:8020",
-    "create:testnet": "graph create venusprotocol/venus-isolated-pools --node https://api.staging.thegraph.com/deploy/",
-    "create:mainnet": "graph create venusprotocol/venus-isolated-pools --node https://api.thegraph.com/deploy/",
     "build:local": "graph build --ipfs http://localhost:5001",
     "build:testnet": "graph build --ipfs https://api.staging.thegraph.com/ipfs/ ",
     "build:mainnet": "graph build --ipfs https://api.thegraph.com/ipfs/ ",

--- a/subgraphs/venus-governance/package.json
+++ b/subgraphs/venus-governance/package.json
@@ -12,8 +12,6 @@
   "scripts": {
     "codegen": "graph codegen",
     "create:local": "graph create venusprotocol/venus-governance --node http://127.0.0.1:8020",
-    "create:testnet": "graph create venusprotocol/venus-governance --node https://api.staging.thegraph.com/deploy/",
-    "create:mainnet": "graph create venusprotocol/venus-governance --node https://api.thegraph.com/deploy/",
     "build:local": "graph build --ipfs http://localhost:5001",
     "build:testnet": "graph build --ipfs https://api.staging.thegraph.com/ipfs/ ",
     "build:mainnet": "graph build --ipfs https://api.thegraph.com/ipfs/ ",

--- a/subgraphs/venus/package.json
+++ b/subgraphs/venus/package.json
@@ -12,8 +12,6 @@
   "scripts": {
     "codegen": "graph codegen",
     "create:local": "graph create venusprotocol/venus-subgraph --node http://127.0.0.1:8020",
-    "create:testnet": "graph create venusprotocol/venus-subgraph --node https://api.staging.thegraph.com/deploy/",
-    "create:mainnet": "graph create venusprotocol/venus-subgraph --node https://api.thegraph.com/deploy/",
     "build:local": "graph build --ipfs http://localhost:5001",
     "build:testnet": "graph build --ipfs https://api.staging.thegraph.com/ipfs/ ",
     "build:mainnet": "graph build --ipfs https://api.thegraph.com/ipfs/ ",


### PR DESCRIPTION
Remove create commands that can only be run by user with organization permissions.

The removed commands are also only used once so they are not particularly useful.