### PR TITLE
create delegate when voting for alpha v1

### DIFF
--- a/subgraphs/venus-governance/src/mappings/alpha.ts
+++ b/subgraphs/venus-governance/src/mappings/alpha.ts
@@ -61,6 +61,17 @@ export function handleProposalExecuted(event: ProposalExecuted): void {
 //   handler: handleVoteCast
 
 export function handleVoteCast(event: VoteCast): void {
+  // Alpha V1 doesn't require staking in the vault so we need to create delegates when casting a vote
+  getOrCreateDelegate(event.params.voter.toHexString());
+  createVoteAlpha(event);
+  const proposalId = event.params.proposalId.toString();
+  const proposal = getProposal(proposalId);
+  if (proposal.status == PENDING) {
+    updateProposalStatus(proposalId, ACTIVE);
+  }
+}
+
+export function handleVoteCastV2(event: VoteCast): void {
   createVoteAlpha(event);
   const proposalId = event.params.proposalId.toString();
   const proposal = getProposal(proposalId);

--- a/subgraphs/venus-governance/template.yaml
+++ b/subgraphs/venus-governance/template.yaml
@@ -67,7 +67,7 @@ dataSources:
         - event: ProposalExecuted(uint256)
           handler: handleProposalExecuted
         - event: VoteCast(address,uint256,bool,uint256)
-          handler: handleVoteCast
+          handler: handleVoteCastV2
   - kind: ethereum/contract
     name: GovernorBravoDelegate
     network: {{ network }}


### PR DESCRIPTION
Governor Alpha v1 allows for voting without staking XVS. For Alpha v2 and later we through an error if a delegate hasn't been created before voting but in v1 we need to create the delegate when voting because it won't exist otherwise