### PR TITLE
declare handlers with function keyword

### DIFF
--- a/subgraphs/venus-governance/src/mappings/bravo.ts
+++ b/subgraphs/venus-governance/src/mappings/bravo.ts
@@ -23,78 +23,78 @@ import {
   updateProposalStatus,
 } from '../operations/update';
 
-export const handleProposalCreated = (event: ProposalCreated): void => {
+export function handleProposalCreated(event: ProposalCreated): void {
   getOrCreateDelegate(event.params.proposer.toHexString());
   createProposal<ProposalCreated>(event);
-};
+}
 
-export const handleProposalCanceled = (event: ProposalCanceled): void => {
+export function handleProposalCanceled(event: ProposalCanceled): void {
   const proposalId = event.params.id.toString();
   updateProposalStatus(proposalId, CANCELLED);
-};
+}
 
-export const handleProposalQueued = (event: ProposalQueued): void => {
+export function handleProposalQueued(event: ProposalQueued): void {
   updateProposalQueued<ProposalQueued>(event);
-};
+}
 
-export const handleProposalExecuted = (event: ProposalExecuted): void => {
+export function handleProposalExecuted(event: ProposalExecuted): void {
   updateProposalExecuted<ProposalExecuted>(event);
-};
+}
 
-export const handleVoteCast = (event: VoteCast): void => {
+export function handleVoteCast(event: VoteCast): void {
   createVoteBravo(event);
   const proposalId = event.params.proposalId.toString();
   const proposal = getProposal(proposalId);
   if (proposal.status == PENDING) {
     updateProposalStatus(proposalId, ACTIVE);
   }
-};
+}
 
-export const handleVotingDelaySet = (event: VotingDelaySet): void => {
+export function handleVotingDelaySet(event: VotingDelaySet): void {
   const governance = getGovernanceEntity();
   governance.votingDelay = event.params.newVotingDelay;
   governance.save();
-};
+}
 
-export const handleVotingPeriodSet = (event: VotingPeriodSet): void => {
+export function handleVotingPeriodSet(event: VotingPeriodSet): void {
   const governance = getGovernanceEntity();
   governance.votingPeriod = event.params.newVotingPeriod;
   governance.save();
-};
+}
 
-export const handleNewImplementation = (event: NewImplementation): void => {
+export function handleNewImplementation(event: NewImplementation): void {
   const governance = getGovernanceEntity();
   governance.implementation = event.params.newImplementation;
   governance.save();
-};
+}
 
-export const handleProposalThresholdSet = (event: ProposalThresholdSet): void => {
+export function handleProposalThresholdSet(event: ProposalThresholdSet): void {
   const governance = getGovernanceEntity();
   governance.proposalThreshold = event.params.newProposalThreshold;
   governance.save();
-};
+}
 
-export const handleNewPendingAdmin = (event: NewPendingAdmin): void => {
+export function handleNewPendingAdmin(event: NewPendingAdmin): void {
   const governance = getGovernanceEntity();
   governance.pendingAdmin = event.params.newPendingAdmin;
   governance.save();
-};
+}
 
-export const handleNewAdmin = (event: NewAdmin): void => {
+export function handleNewAdmin(event: NewAdmin): void {
   const governance = getGovernanceEntity();
   governance.admin = event.params.newAdmin;
   governance.pendingAdmin = null;
   governance.save();
-};
+}
 
-export const handleNewGuardian = (event: NewGuardian): void => {
+export function handleNewGuardian(event: NewGuardian): void {
   const governance = getGovernanceEntity();
   governance.guardian = event.params.newGuardian;
   governance.save();
-};
+}
 
-export const handleProposalMaxOperationsUpdated = (event: ProposalMaxOperationsUpdated): void => {
+export function handleProposalMaxOperationsUpdated(event: ProposalMaxOperationsUpdated): void {
   const governance = getGovernanceEntity();
   governance.proposalMaxOperations = event.params.newMaxOperations;
   governance.save();
-};
+}


### PR DESCRIPTION
If the handlers are defined without the function keyword they can't be found when queried. This is likely due to a difference between how Assemblyscript compiles functions declared with the keyword and arrow functions