### PR TITLE
[VEN-829][VEN-830] fix: removed duplicate and unneeded values

### DIFF
--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -173,14 +173,10 @@ type AccountVToken @entity {
 
     "VToken balance of the user"
     vTokenBalance: BigDecimal!
-    "Total amount of underlying supplied"
-    totalUnderlyingSupplied: BigDecimal!
     "Total amount of underling redeemed"
     totalUnderlyingRedeemed: BigDecimal!
     "The value of the borrow index upon users last interaction"
     accountBorrowIndex: BigDecimal!
-    "Total amount underlying borrowed, exclusive of interest"
-    totalUnderlyingBorrowed: BigDecimal!
     "Total amount underlying repaid"
     totalUnderlyingRepaid: BigDecimal!
     "Current borrow balance stored in contract (exclusive of interest since accrualBlockNumber)"

--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -104,10 +104,6 @@ type Market @entity {
     supplyRate: BigDecimal!
     "VToken symbol"
     symbol: String!
-    "Borrows in the market"
-    totalBorrows: BigDecimal!
-    "VToken supply. VTokens have 8 decimals"
-    totalSupply: BigDecimal!
     "Underlying token address"
     underlyingAddress: Bytes!
     "Underlying token name"

--- a/subgraphs/isolated-pools/src/mappings/vToken.ts
+++ b/subgraphs/isolated-pools/src/mappings/vToken.ts
@@ -233,8 +233,6 @@ export function handleTransfer(event: Transfer): void {
       event.block.number,
       event.logIndex,
       event.params.amount,
-      market.exchangeRate,
-      market.underlyingDecimals,
     );
   }
 

--- a/subgraphs/isolated-pools/src/operations/create.ts
+++ b/subgraphs/isolated-pools/src/operations/create.ts
@@ -101,8 +101,6 @@ export function createMarket(comptroller: Address, vTokenAddress: Address): Mark
   market.exchangeRate = zeroBigDecimal;
   market.reserves = zeroBigDecimal;
   market.supplyRate = zeroBigDecimal;
-  market.totalBorrows = zeroBigDecimal;
-  market.totalSupply = zeroBigDecimal;
   market.underlyingPrice = zeroBigDecimal;
   market.accrualBlockNumber = 0;
   market.blockTimestamp = 0;

--- a/subgraphs/isolated-pools/src/operations/getOrCreate.ts
+++ b/subgraphs/isolated-pools/src/operations/getOrCreate.ts
@@ -88,10 +88,8 @@ export const getOrCreateAccountVToken = (
     const vTokenContract = BEP20.bind(marketAddress);
     accountVToken.vTokenBalance = new BigDecimal(vTokenContract.balanceOf(accountAddress));
 
-    accountVToken.totalUnderlyingSupplied = zeroBigDecimal;
     accountVToken.totalUnderlyingRedeemed = zeroBigDecimal;
     accountVToken.accountBorrowIndex = zeroBigDecimal;
-    accountVToken.totalUnderlyingBorrowed = zeroBigDecimal;
     accountVToken.totalUnderlyingRepaid = zeroBigDecimal;
     accountVToken.storedBorrowBalance = zeroBigDecimal;
   }

--- a/subgraphs/isolated-pools/src/operations/update.ts
+++ b/subgraphs/isolated-pools/src/operations/update.ts
@@ -218,7 +218,6 @@ export const updateMarket = (
 
   market.accrualBlockNumber = marketContract.accrualBlockNumber().toI32();
   market.blockTimestamp = blockTimestamp;
-  market.totalSupply = marketContract.totalSupply().toBigDecimal().div(vTokenDecimalsBigDecimal);
 
   /* Exchange rate explanation
      In Practice
@@ -246,12 +245,6 @@ export const updateMarket = (
 
   market.reserves = marketContract
     .totalReserves()
-    .toBigDecimal()
-    .div(exponentToBigDecimal(market.underlyingDecimals))
-    .truncate(market.underlyingDecimals);
-
-  market.totalBorrows = marketContract
-    .totalBorrows()
     .toBigDecimal()
     .div(exponentToBigDecimal(market.underlyingDecimals))
     .truncate(market.underlyingDecimals);

--- a/subgraphs/isolated-pools/src/operations/update.ts
+++ b/subgraphs/isolated-pools/src/operations/update.ts
@@ -65,16 +65,12 @@ export const updateAccountVTokenBorrow = (
     blockNumber,
     logIndex,
   );
-  const totalUnderlyingBorrowed = accountVToken.totalUnderlyingBorrowed.plus(
-    borrowAmount.toBigDecimal().div(exponentToBigDecimal(underlyingDecimals)),
-  );
   const storedBorrowBalance = accountBorrows
     .toBigDecimal()
     .div(exponentToBigDecimal(underlyingDecimals))
     .truncate(underlyingDecimals);
   accountVToken.storedBorrowBalance = storedBorrowBalance;
   accountVToken.accountBorrowIndex = borrowIndex;
-  accountVToken.totalUnderlyingBorrowed = totalUnderlyingBorrowed;
   accountVToken.save();
   return accountVToken as AccountVToken;
 };
@@ -101,16 +97,12 @@ export const updateAccountVTokenRepayBorrow = (
     blockNumber,
     logIndex,
   );
-  const totalUnderlyingBorrowed = accountVToken.totalUnderlyingBorrowed.plus(
-    repayAmount.toBigDecimal().div(exponentToBigDecimal(underlyingDecimals)),
-  );
   const storedBorrowBalance = accountBorrows
     .toBigDecimal()
     .div(exponentToBigDecimal(underlyingDecimals))
     .truncate(underlyingDecimals);
   accountVToken.storedBorrowBalance = storedBorrowBalance;
   accountVToken.accountBorrowIndex = borrowIndex;
-  accountVToken.totalUnderlyingBorrowed = totalUnderlyingBorrowed;
   accountVToken.save();
   return accountVToken as AccountVToken;
 };
@@ -158,12 +150,7 @@ export const updateAccountVTokenTransferTo = (
   blockNumber: BigInt,
   logIndex: BigInt,
   amount: BigInt,
-  exchangeRate: BigDecimal,
-  underlyingDecimals: i32,
 ): AccountVToken => {
-  const amountUnderlying = exchangeRate.times(amount.toBigDecimal().div(vTokenDecimalsBigDecimal));
-  const amountUnderylingTruncated = amountUnderlying.truncate(underlyingDecimals);
-
   const accountVToken = updateAccountVToken(
     marketAddress,
     marketSymbol,
@@ -177,9 +164,6 @@ export const updateAccountVTokenTransferTo = (
   accountVToken.vTokenBalance = accountVToken.vTokenBalance.plus(
     amount.toBigDecimal().div(vTokenDecimalsBigDecimal).truncate(vTokenDecimals),
   );
-
-  accountVToken.totalUnderlyingSupplied =
-    accountVToken.totalUnderlyingSupplied.plus(amountUnderylingTruncated);
 
   accountVToken.save();
   return accountVToken as AccountVToken;

--- a/subgraphs/isolated-pools/tests/VToken/index.test.ts
+++ b/subgraphs/isolated-pools/tests/VToken/index.test.ts
@@ -451,11 +451,11 @@ describe('VToken', () => {
 
     assertMarketDocument('accrualBlockNumber', '999');
     assertMarketDocument('blockTimestamp', accrueInterestEvent.block.timestamp.toString());
-    assertMarketDocument('totalSupply', '365045.67163409');
+    assertMarketDocument('treasuryTotalSupplyWei', '36504567163409');
     assertMarketDocument('exchangeRate', '0.000000000320502536');
     assertMarketDocument('borrowIndex', '4.852094820647174144');
     assertMarketDocument('reserves', '5.128924555022289393');
-    assertMarketDocument('totalBorrows', '2.641234234636158123');
+    assertMarketDocument('treasuryTotalBorrowsWei', '2641234234636158123');
     assertMarketDocument('cash', '1.418171344423412457');
     assertMarketDocument('borrowRate', '0.000000000012678493');
     assertMarketDocument('supplyRate', '0.000000000012678493');

--- a/subgraphs/isolated-pools/tests/VToken/index.test.ts
+++ b/subgraphs/isolated-pools/tests/VToken/index.test.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, BigInt, ethereum } from '@graphprotocol/graph-ts';
+import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts';
 import { createMockedFunction } from 'matchstick-as';
 import {
   afterEach,
@@ -34,7 +34,6 @@ import {
   handleTransfer,
 } from '../../src/mappings/vToken';
 import { getMarket } from '../../src/operations/get';
-import { getOrCreateAccountVToken } from '../../src/operations/getOrCreate';
 import exponentToBigDecimal from '../../src/utilities/exponentToBigDecimal';
 import { getAccountVTokenId, getTransactionEventId } from '../../src/utilities/ids';
 import { createMarketAddedEvent } from '../Pool/events';
@@ -212,15 +211,7 @@ describe('VToken', () => {
     );
     const accountVTokenId = getAccountVTokenId(aaaTokenAddress, borrower);
     const market = getMarket(aaaTokenAddress);
-    const accountVToken = getOrCreateAccountVToken(market.symbol, borrower, aaaTokenAddress);
-    // Clone the value to remove the reference
-    const totalUnderlyingBorrowedOriginal = accountVToken.totalUnderlyingBorrowed.times(
-      new BigDecimal(new BigInt(1)),
-    );
     const underlyingDecimals = market.underlyingDecimals;
-    const totalUnderlyingBorrowed = totalUnderlyingBorrowedOriginal.plus(
-      borrowAmount.toBigDecimal().div(exponentToBigDecimal(underlyingDecimals)),
-    );
     const storedBorrowBalance = accountBorrows
       .toBigDecimal()
       .div(exponentToBigDecimal(underlyingDecimals))
@@ -248,12 +239,6 @@ describe('VToken', () => {
       accountVTokenId,
       'accrualBlockNumber',
       borrowEvent.block.number.toString(),
-    );
-    assert.fieldEquals(
-      'AccountVToken',
-      accountVTokenId,
-      'totalUnderlyingBorrowed',
-      totalUnderlyingBorrowed.toString(),
     );
     assert.fieldEquals(
       'AccountVToken',
@@ -301,15 +286,7 @@ describe('VToken', () => {
     );
     const accountVTokenId = getAccountVTokenId(aaaTokenAddress, borrower);
     const market = getMarket(aaaTokenAddress);
-    const accountVToken = getOrCreateAccountVToken(market.symbol, borrower, aaaTokenAddress);
-    // Clone the value to remove the reference
-    const totalUnderlyingBorrowedOriginal = accountVToken.totalUnderlyingBorrowed.times(
-      new BigDecimal(new BigInt(1)),
-    );
     const underlyingDecimals = market.underlyingDecimals;
-    const totalUnderlyingBorrowed = totalUnderlyingBorrowedOriginal.plus(
-      repayAmount.toBigDecimal().div(exponentToBigDecimal(underlyingDecimals)),
-    );
     const storedBorrowBalance = accountBorrows
       .toBigDecimal()
       .div(exponentToBigDecimal(underlyingDecimals))
@@ -354,12 +331,6 @@ describe('VToken', () => {
       accountVTokenId,
       'accountBorrowIndex',
       market.borrowIndex.toString(),
-    );
-    assert.fieldEquals(
-      'AccountVToken',
-      accountVTokenId,
-      'totalUnderlyingBorrowed',
-      totalUnderlyingBorrowed.toString(),
     );
   });
 
@@ -598,13 +569,6 @@ describe('VToken', () => {
       accountVTokenId,
       'vTokenBalance',
       '262059926715398.98726345',
-    );
-
-    assert.fieldEquals(
-      'AccountVToken',
-      accountVTokenId,
-      'totalUnderlyingSupplied',
-      '0.016814221346686847',
     );
   });
 


### PR DESCRIPTION
## Jira ticket(s)

[VEN-829](https://jira.toolsfdg.net/browse/VEN-829)
[VEN-830](https://jira.toolsfdg.net/browse/VEN-830)

## Changes

Removed duplicated `BigDecimals` values:
 - `totalBorrows`
 - `totalSupply`

 Kept `BigInt` values:
- `treasuryTotalBorrowsWei` 
- `treasuryTotalSupplyWei`

Also removed `totalUnderlyingSupplied` and `totalUnderlyingBorrowed` as per Slack conversation.