### PR TITLE
[VEN-844] Handling NewSupplyCap comptroller event

### DIFF
--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -113,7 +113,7 @@ type Market @entity {
     "Underlying token symbol"
     underlyingSymbol: String!
     "Max token borrow amount allowed"
-    borrowCap: BigInt!
+    borrowCapWei: BigInt!
     "Total borrowed"
     treasuryTotalBorrowsWei: BigInt!
     "Total supplied"
@@ -133,7 +133,7 @@ type Market @entity {
     "Underlying token decimal length"
     underlyingDecimals: Int!
     "Supply cap set for market"
-    supplyCap: BigInt!
+    supplyCapWei: BigInt!
 }
 
 """

--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -132,6 +132,8 @@ type Market @entity {
     underlyingPriceUsd: BigDecimal!
     "Underlying token decimal length"
     underlyingDecimals: Int!
+    "Supply cap set for market"
+    supplyCap: BigInt!
 }
 
 """

--- a/subgraphs/isolated-pools/src/mappings/pool.ts
+++ b/subgraphs/isolated-pools/src/mappings/pool.ts
@@ -119,7 +119,7 @@ export function handleNewBorrowCap(event: NewBorrowCap): void {
   const vTokenAddress = event.params.vToken;
   const borrowCap = event.params.newBorrowCap;
   const market = getMarket(vTokenAddress);
-  market.borrowCap = borrowCap;
+  market.borrowCapWei = borrowCap;
   market.save();
 }
 
@@ -137,6 +137,6 @@ export function handleNewSupplyCap(event: NewSupplyCap): void {
   const vTokenAddress = event.params.vToken;
   const newSupplyCap = event.params.newSupplyCap;
   const market = getMarket(vTokenAddress);
-  market.supplyCap = newSupplyCap;
+  market.supplyCapWei = newSupplyCap;
   market.save();
 }

--- a/subgraphs/isolated-pools/src/mappings/pool.ts
+++ b/subgraphs/isolated-pools/src/mappings/pool.ts
@@ -8,6 +8,7 @@ import {
   NewLiquidationIncentive,
   NewMinLiquidatableCollateral,
   NewPriceOracle,
+  NewSupplyCap,
 } from '../../generated/PoolRegistry/Comptroller';
 import { defaultMantissaFactorBigDecimal } from '../constants';
 import { getMarket } from '../operations/get';
@@ -130,4 +131,12 @@ export function handleNewMinLiquidatableCollateral(event: NewMinLiquidatableColl
     pool.minLiquidatableCollateral = newMinLiquidatableCollateral;
     pool.save();
   }
+}
+
+export function handleNewSupplyCap(event: NewSupplyCap): void {
+  const vTokenAddress = event.params.vToken;
+  const newSupplyCap = event.params.newSupplyCap;
+  const market = getMarket(vTokenAddress);
+  market.supplyCap = newSupplyCap;
+  market.save();
 }

--- a/subgraphs/isolated-pools/src/operations/create.ts
+++ b/subgraphs/isolated-pools/src/operations/create.ts
@@ -109,6 +109,7 @@ export function createMarket(comptroller: Address, vTokenAddress: Address): Mark
   market.borrowCap = BigInt.fromI32(0);
   market.treasuryTotalBorrowsWei = BigInt.fromI32(0);
   market.treasuryTotalSupplyWei = BigInt.fromI32(0);
+  market.supplyCap = BigInt.fromI32(0);
   market.save();
   return market;
 }

--- a/subgraphs/isolated-pools/src/operations/create.ts
+++ b/subgraphs/isolated-pools/src/operations/create.ts
@@ -106,10 +106,10 @@ export function createMarket(comptroller: Address, vTokenAddress: Address): Mark
   market.blockTimestamp = 0;
   market.borrowIndex = zeroBigDecimal;
   market.reserveFactor = getReserveFactorMantissa(vTokenContract);
-  market.borrowCap = BigInt.fromI32(0);
+  market.borrowCapWei = BigInt.fromI32(0);
   market.treasuryTotalBorrowsWei = BigInt.fromI32(0);
   market.treasuryTotalSupplyWei = BigInt.fromI32(0);
-  market.supplyCap = BigInt.fromI32(0);
+  market.supplyCapWei = BigInt.fromI32(0);
   market.save();
   return market;
 }

--- a/subgraphs/isolated-pools/template.yaml
+++ b/subgraphs/isolated-pools/template.yaml
@@ -90,6 +90,8 @@ templates:
           handler: handleNewBorrowCapGuardian
         - event: NewMinLiquidatableCollateral(uint256,uint256)
           handler: handleNewMinLiquidatableCollateral
+        - event: NewSupplyCap(indexed address,uint256)
+          handler: handleNewSupplyCap
   - name: VToken
     kind: ethereum/contract
     network: {{ network }}

--- a/subgraphs/isolated-pools/tests/Pool/events.ts
+++ b/subgraphs/isolated-pools/tests/Pool/events.ts
@@ -11,6 +11,7 @@ import {
   NewLiquidationIncentive as NewLiquidationIncentiveEvent,
   NewMinLiquidatableCollateral as NewMinLiquidatableCollateralEvent,
   NewPriceOracle as NewPriceOracleEvent,
+  NewSupplyCap as NewSupplyCapEvent,
 } from '../../generated/PoolRegistry/Comptroller';
 import { MarketAdded as MarketAddedEvent } from '../../generated/PoolRegistry/PoolRegistry';
 
@@ -226,6 +227,25 @@ export const createNewMinLiquidatableCollateralEvent = (
     ethereum.Value.fromUnsignedBigInt(newMinLiquidatableCollateral),
   );
   event.parameters.push(newMinLiquidatableCollateralParam);
+
+  return event;
+};
+
+export const createNewSupplyCapEvent = (
+  vTokenAddress: Address,
+  newSupplyCap: BigInt,
+): NewSupplyCapEvent => {
+  const event = changetype<NewSupplyCapEvent>(newMockEvent());
+  event.parameters = [];
+
+  const vTokenParam = new ethereum.EventParam('vToken', ethereum.Value.fromAddress(vTokenAddress));
+  event.parameters.push(vTokenParam);
+
+  const newSupplyCapParam = new ethereum.EventParam(
+    'newSupplyCap',
+    ethereum.Value.fromUnsignedBigInt(newSupplyCap),
+  );
+  event.parameters.push(newSupplyCapParam);
 
   return event;
 };

--- a/subgraphs/isolated-pools/tests/Pool/index.test.ts
+++ b/subgraphs/isolated-pools/tests/Pool/index.test.ts
@@ -291,7 +291,7 @@ describe('Pool Events', () => {
     handleNewBorrowCap(newBorrowCapEvent);
 
     assert.fieldEquals('Market', vTokenAddress.toHex(), 'id', vTokenAddress.toHexString());
-    assert.fieldEquals('Market', vTokenAddress.toHex(), 'borrowCap', newBorrowCap.toString());
+    assert.fieldEquals('Market', vTokenAddress.toHex(), 'borrowCapWei', newBorrowCap.toString());
   });
 
   test('indexes NewMinLiquidatableCollateral event', () => {
@@ -319,6 +319,6 @@ describe('Pool Events', () => {
     handleNewSupplyCap(newSupplyCapEvent);
 
     assert.fieldEquals('Market', vTokenAddress.toHex(), 'id', vTokenAddress.toHexString());
-    assert.fieldEquals('Market', vTokenAddress.toHex(), 'supplyCap', newSupplyCap.toString());
+    assert.fieldEquals('Market', vTokenAddress.toHex(), 'supplyCapWei', newSupplyCap.toString());
   });
 });

--- a/subgraphs/isolated-pools/tests/Pool/index.test.ts
+++ b/subgraphs/isolated-pools/tests/Pool/index.test.ts
@@ -21,6 +21,7 @@ import {
   handleNewLiquidationIncentive,
   handleNewMinLiquidatableCollateral,
   handleNewPriceOracle,
+  handleNewSupplyCap,
 } from '../../src/mappings/pool';
 import { handleMarketAdded, handlePoolRegistered } from '../../src/mappings/poolRegistry';
 import {
@@ -42,6 +43,7 @@ import {
   createNewLiquidationIncentiveEvent,
   createNewMinLiquidatableCollateralEvent,
   createNewPriceOracleEvent,
+  createNewSupplyCapEvent,
 } from './events';
 
 const vTokenAddress = Address.fromString('0x0000000000000000000000000000000000000a0a');
@@ -308,5 +310,15 @@ describe('Pool Events', () => {
       'minLiquidatableCollateral',
       newMinLiquidatableCollateral.toString(),
     );
+  });
+
+  test('indexes NewSupplyCap event', () => {
+    const newSupplyCap = BigInt.fromI64(5000000000000000000);
+    const newSupplyCapEvent = createNewSupplyCapEvent(vTokenAddress, newSupplyCap);
+
+    handleNewSupplyCap(newSupplyCapEvent);
+
+    assert.fieldEquals('Market', vTokenAddress.toHex(), 'id', vTokenAddress.toHexString());
+    assert.fieldEquals('Market', vTokenAddress.toHex(), 'supplyCap', newSupplyCap.toString());
   });
 });

--- a/subgraphs/isolated-pools/tests/integration/pool.ts
+++ b/subgraphs/isolated-pools/tests/integration/pool.ts
@@ -101,7 +101,10 @@ describe('Pools', function () {
       expect(m.underlyingName).to.equal(underlyingNames[idx]);
       expect(m.underlyingPrice).to.equal('0');
       expect(m.underlyingSymbol).to.equal(underlyingSymbols[idx]);
-      expect(m.borrowCap).to.equal(
+      expect(m.borrowCapWei).to.equal(
+        '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+      );
+      expect(m.supplyCapWei).to.equal(
         '115792089237316195423570985008687907853269984665640564039457584007913129639935',
       );
       expect(m.accrualBlockNumber).to.equal(0);
@@ -313,7 +316,7 @@ describe('Pools', function () {
     const { markets: marketsBeforeUpdate } = data!;
 
     marketsBeforeUpdate.forEach(m => {
-      expect(m.borrowCap).to.equal(
+      expect(m.borrowCapWei).to.equal(
         '115792089237316195423570985008687907853269984665640564039457584007913129639935',
       );
     });
@@ -338,7 +341,7 @@ describe('Pools', function () {
     expect(marketsData).to.not.be.equal(undefined);
     const { markets } = marketsData!;
     markets.forEach(m => {
-      expect(m.borrowCap).to.equal('0');
+      expect(m.borrowCapWei).to.equal('0');
     });
   });
 
@@ -374,7 +377,7 @@ describe('Pools', function () {
     const { markets: marketsBeforeUpdate } = data!;
 
     marketsBeforeUpdate.forEach(m => {
-      expect(m.supplyCap).to.equal(
+      expect(m.supplyCapWei).to.equal(
         '115792089237316195423570985008687907853269984665640564039457584007913129639935',
       );
     });
@@ -399,7 +402,7 @@ describe('Pools', function () {
     expect(marketsData).to.not.be.equal(undefined);
     const { markets } = marketsData!;
     markets.forEach(m => {
-      expect(m.supplyCap).to.equal('100');
+      expect(m.supplyCapWei).to.equal('100');
     });
   });
 });

--- a/subgraphs/isolated-pools/tests/integration/queries/marketsQuery.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/marketsQuery.graphql
@@ -24,5 +24,6 @@ query Markets {
     reserveFactor
     underlyingPriceUsd
     underlyingDecimals
+    supplyCap
   }
 }

--- a/subgraphs/isolated-pools/tests/integration/queries/marketsQuery.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/marketsQuery.graphql
@@ -17,13 +17,13 @@ query Markets {
     underlyingName
     underlyingPrice
     underlyingSymbol
-    borrowCap
+    borrowCapWei
     accrualBlockNumber
     blockTimestamp
     borrowIndex
     reserveFactor
     underlyingPriceUsd
     underlyingDecimals
-    supplyCap
+    supplyCapWei
   }
 }


### PR DESCRIPTION
## Jira ticket(s)

VEN-844

## Changes

- Event `NewSupplyCap` is now handled
- Updated `Market` schema to return its corresponding `supplyCap` value
- Added unit test for `handleNewSupplyCap`
- Added integration test for `handleNewSupplyCap`