### PR TITLE
[VEN-900] Added new fields to Market and AccountVToken

### DIFF
--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -147,6 +147,9 @@ type Market @entity {
 
     "Multiplier representing the collateralization after which the borrow is eligible for liquidation"
     liquidationThreshold: BigInt!
+
+    "Accounts who participate in this market"
+    accounts: [AccountVToken!]! @derivedFrom(field:"market")
 }
 
 """

--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -144,6 +144,9 @@ type Market @entity {
     supplierCount: BigInt!
     "Number of accounts currently borrowing from this market"
     borrowerCount: BigInt!
+
+    "Multiplier representing the collateralization after which the borrow is eligible for liquidation"
+    liquidationThreshold: BigInt!
 }
 
 """
@@ -182,19 +185,20 @@ type AccountVToken @entity {
     badDebt: [AccountVTokenBadDebt!]! @derivedFrom(field:"account")
     "Block number this asset was updated at in the contract"
     accrualBlockNumber: BigInt!
+    
+    "Amount of tokens supplied to the market"
+    userSupplyBalanceWei: BigInt!
+    "Current borrow balance stored in contract (exclusive of interest since accrualBlockNumber)"
+    userBorrowBalanceWei: BigInt!
     "True if user is entered, false if they are exited"
-    enteredMarket: Boolean!
+    isCollateralOfUser: Boolean!
 
-    "VToken balance of the user"
-    vTokenBalance: BigDecimal!
     "Total amount of underling redeemed"
     totalUnderlyingRedeemed: BigDecimal!
     "The value of the borrow index upon users last interaction"
     accountBorrowIndex: BigDecimal!
     "Total amount underlying repaid"
     totalUnderlyingRepaid: BigDecimal!
-    "Current borrow balance stored in contract (exclusive of interest since accrualBlockNumber)"
-    storedBorrowBalance: BigDecimal!
 }
 
 """

--- a/subgraphs/isolated-pools/src/mappings/pool.ts
+++ b/subgraphs/isolated-pools/src/mappings/pool.ts
@@ -6,6 +6,7 @@ import {
   NewCloseFactor,
   NewCollateralFactor,
   NewLiquidationIncentive,
+  NewLiquidationThreshold,
   NewMinLiquidatableCollateral,
   NewPriceOracle,
   NewSupplyCap,
@@ -87,6 +88,14 @@ export function handleNewCollateralFactor(event: NewCollateralFactor): void {
   market.collateralFactor = newCollateralFactorMantissa
     .toBigDecimal()
     .div(defaultMantissaFactorBigDecimal);
+  market.save();
+}
+
+export function handleNewLiquidationThreshold(event: NewLiquidationThreshold): void {
+  const poolAddress = event.address;
+  const vTokenAddress = event.params.vToken;
+  const market = getOrCreateMarket(poolAddress, vTokenAddress);
+  market.liquidationThreshold = event.params.newLiquidationThresholdMantissa;
   market.save();
 }
 

--- a/subgraphs/isolated-pools/src/mappings/vToken.ts
+++ b/subgraphs/isolated-pools/src/mappings/vToken.ts
@@ -112,7 +112,6 @@ export function handleBorrow(event: Borrow): void {
     event.params.borrowAmount,
     event.params.accountBorrows,
     market.borrowIndex,
-    market.underlyingDecimals,
   );
 
   createBorrowTransaction(event, market.underlyingDecimals);
@@ -153,7 +152,6 @@ export function handleRepayBorrow(event: RepayBorrow): void {
     event.params.repayAmount,
     event.params.accountBorrows,
     market.borrowIndex,
-    market.underlyingDecimals,
   );
 
   createRepayBorrowTransaction(event, market.underlyingDecimals);

--- a/subgraphs/isolated-pools/src/operations/create.ts
+++ b/subgraphs/isolated-pools/src/operations/create.ts
@@ -119,6 +119,7 @@ export function createMarket(comptroller: Address, vTokenAddress: Address): Mark
   market.supplyCapWei = zeroBigInt32;
   market.supplierCount = zeroBigInt32;
   market.borrowerCount = zeroBigInt32;
+  market.liquidationThreshold = zeroBigInt32;
 
   market.save();
   return market;

--- a/subgraphs/isolated-pools/src/operations/getOrCreate.ts
+++ b/subgraphs/isolated-pools/src/operations/getOrCreate.ts
@@ -1,6 +1,6 @@
-import { Address, BigDecimal, BigInt, Bytes } from '@graphprotocol/graph-ts';
+import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts';
 
-import { BEP20 } from '../../generated/PoolRegistry/BEP20';
+import { VToken } from '../../generated/PoolRegistry/VToken';
 import {
   Account,
   AccountVToken,
@@ -81,17 +81,20 @@ export const getOrCreateAccountVToken = (
     accountVToken.symbol = marketSymbol;
     accountVToken.account = accountAddress.toHexString();
     accountVToken.market = marketAddress.toHexString();
-    accountVToken.enteredMarket = enteredMarket;
+    accountVToken.isCollateralOfUser = enteredMarket;
     accountVToken.accrualBlockNumber = BigInt.fromI32(0);
     // we need to set an initial real onchain value to this otherwise it will never
     // be accurate
-    const vTokenContract = BEP20.bind(marketAddress);
-    accountVToken.vTokenBalance = new BigDecimal(vTokenContract.balanceOf(accountAddress));
+    const vTokenContract = VToken.bind(marketAddress);
+    const accountSnapshot = vTokenContract.getAccountSnapshot(accountAddress);
+    const suppliedAmountWei = accountSnapshot.value1;
+    const borrowedAmountWei = accountSnapshot.value2;
+    accountVToken.userSupplyBalanceWei = suppliedAmountWei;
+    accountVToken.userBorrowBalanceWei = borrowedAmountWei;
 
     accountVToken.totalUnderlyingRedeemed = zeroBigDecimal;
     accountVToken.accountBorrowIndex = zeroBigDecimal;
     accountVToken.totalUnderlyingRepaid = zeroBigDecimal;
-    accountVToken.storedBorrowBalance = zeroBigDecimal;
   }
   return accountVToken;
 };

--- a/subgraphs/isolated-pools/src/operations/update.ts
+++ b/subgraphs/isolated-pools/src/operations/update.ts
@@ -7,7 +7,6 @@ import {
   RiskRatings,
   defaultMantissaFactorBigDecimal,
   mantissaFactor,
-  vTokenDecimals,
   vTokenDecimalsBigDecimal,
   zeroBigDecimal,
 } from '../constants';
@@ -54,7 +53,6 @@ export const updateAccountVTokenBorrow = (
   borrowAmount: BigInt,
   accountBorrows: BigInt,
   borrowIndex: BigDecimal,
-  underlyingDecimals: i32,
 ): AccountVToken => {
   const accountVToken = updateAccountVToken(
     marketAddress,
@@ -65,11 +63,7 @@ export const updateAccountVTokenBorrow = (
     blockNumber,
     logIndex,
   );
-  const storedBorrowBalance = accountBorrows
-    .toBigDecimal()
-    .div(exponentToBigDecimal(underlyingDecimals))
-    .truncate(underlyingDecimals);
-  accountVToken.storedBorrowBalance = storedBorrowBalance;
+  accountVToken.userBorrowBalanceWei = accountBorrows;
   accountVToken.accountBorrowIndex = borrowIndex;
   accountVToken.save();
   return accountVToken as AccountVToken;
@@ -86,7 +80,6 @@ export const updateAccountVTokenRepayBorrow = (
   repayAmount: BigInt,
   accountBorrows: BigInt,
   borrowIndex: BigDecimal,
-  underlyingDecimals: i32,
 ): AccountVToken => {
   const accountVToken = updateAccountVToken(
     marketAddress,
@@ -97,11 +90,7 @@ export const updateAccountVTokenRepayBorrow = (
     blockNumber,
     logIndex,
   );
-  const storedBorrowBalance = accountBorrows
-    .toBigDecimal()
-    .div(exponentToBigDecimal(underlyingDecimals))
-    .truncate(underlyingDecimals);
-  accountVToken.storedBorrowBalance = storedBorrowBalance;
+  accountVToken.userBorrowBalanceWei = accountBorrows;
   accountVToken.accountBorrowIndex = borrowIndex;
   accountVToken.save();
   return accountVToken as AccountVToken;
@@ -131,9 +120,7 @@ export const updateAccountVTokenTransferFrom = (
     blockNumber,
     logIndex,
   );
-  accountVToken.vTokenBalance = accountVToken.vTokenBalance.minus(
-    amount.toBigDecimal().div(vTokenDecimalsBigDecimal).truncate(vTokenDecimals),
-  );
+  accountVToken.userSupplyBalanceWei = accountVToken.userSupplyBalanceWei.minus(amount);
 
   accountVToken.totalUnderlyingRedeemed =
     accountVToken.totalUnderlyingRedeemed.plus(amountUnderylingTruncated);
@@ -161,9 +148,7 @@ export const updateAccountVTokenTransferTo = (
     logIndex,
   );
 
-  accountVToken.vTokenBalance = accountVToken.vTokenBalance.plus(
-    amount.toBigDecimal().div(vTokenDecimalsBigDecimal).truncate(vTokenDecimals),
-  );
+  accountVToken.userSupplyBalanceWei = accountVToken.userSupplyBalanceWei.plus(amount);
 
   accountVToken.save();
   return accountVToken as AccountVToken;

--- a/subgraphs/isolated-pools/subgraph-client/index.ts
+++ b/subgraphs/isolated-pools/subgraph-client/index.ts
@@ -2,6 +2,7 @@ import { Client as UrqlClient, createClient } from 'urql/core';
 
 import {
   AccountByIdDocument,
+  AccountFromMarketDocument,
   AccountVTokenTransactionsDocument,
   AccountVTokensDocument,
   MarketActionsDocument,
@@ -52,6 +53,13 @@ class SubgraphClient {
 
   async getMarketActions() {
     const result = await this.urqlClient.query(MarketActionsDocument, {}).toPromise();
+    return result;
+  }
+
+  async getAccountFromMarket(marketId: string, accountId: string) {
+    const result = await this.urqlClient
+      .query(AccountFromMarketDocument, { marketId, accountId })
+      .toPromise();
     return result;
   }
 }

--- a/subgraphs/isolated-pools/template.yaml
+++ b/subgraphs/isolated-pools/template.yaml
@@ -78,6 +78,8 @@ templates:
           handler: handleNewCloseFactor
         - event: NewCollateralFactor(address,uint256,uint256)
           handler: handleNewCollateralFactor
+        - event: NewLiquidationThreshold(address,uint256,uint256)
+          handler: handleNewLiquidationThreshold
         - event: NewLiquidationIncentive(uint256,uint256)
           handler: handleNewLiquidationIncentive
         - event: NewPriceOracle(address,address)

--- a/subgraphs/isolated-pools/tests/integration/queries/accountFromMarket.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/accountFromMarket.graphql
@@ -1,0 +1,21 @@
+query AccountFromMarket($marketId: ID!, $accountId: ID!){
+  market(id: $marketId) {
+    accounts(where: {id: $accountId}) {
+      transactions { 
+        id
+      }
+      badDebt {
+        id
+        amount
+        timestamp
+        block
+      }
+      isCollateralOfUser
+      userSupplyBalanceWei
+      userBorrowBalanceWei
+      totalUnderlyingRedeemed
+      accountBorrowIndex
+      totalUnderlyingRepaid
+    }
+  }
+}

--- a/subgraphs/isolated-pools/tests/integration/queries/accountVTokens.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/accountVTokens.graphql
@@ -17,11 +17,11 @@ query AccountVTokens  {
       timestamp
       block
     }
-    enteredMarket
-    vTokenBalance
+    isCollateralOfUser
+    userSupplyBalanceWei
+    userBorrowBalanceWei
     totalUnderlyingRedeemed
     accountBorrowIndex
     totalUnderlyingRepaid
-    storedBorrowBalance
   }
 }


### PR DESCRIPTION
## Jira ticket(s)

VEN-900

## Changes
Added to Market:
- liquidationThreshold

Reworked on AccountVToken:
- enteredMarket renamed to isCollateralOfUser
- vTokenBalance renamed to userSupplyBalanceWei and turned into a BigInt (from tokens to wei)
- storedBorrowBalance reanamed to userBorrowBalanceWei and turned into a BigInt (from tokens to wei)

Added new Pool/Comptroller event:
- NewLiquidationThreshold
