### PR TITLE
[VEN-1057] Turned totalUnderlyingRedeemed and totalUnderlyingRepaid into wei values

### DIFF
--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -197,11 +197,11 @@ type AccountVToken @entity {
     isCollateralOfUser: Boolean!
 
     "Total amount of underling redeemed"
-    totalUnderlyingRedeemed: BigDecimal!
+    totalUnderlyingRedeemedWei: BigDecimal!
     "The value of the borrow index upon users last interaction"
     accountBorrowIndex: BigDecimal!
     "Total amount underlying repaid"
-    totalUnderlyingRepaid: BigDecimal!
+    totalUnderlyingRepaidWei: BigDecimal!
 }
 
 """

--- a/subgraphs/isolated-pools/src/operations/getOrCreate.ts
+++ b/subgraphs/isolated-pools/src/operations/getOrCreate.ts
@@ -8,7 +8,7 @@ import {
   Market,
   Pool,
 } from '../../generated/schema';
-import { zeroBigDecimal } from '../constants';
+import { zeroBigDecimal, zeroBigInt32 } from '../constants';
 import {
   getAccountVTokenId,
   getAccountVTokenTransactionId,
@@ -82,7 +82,7 @@ export const getOrCreateAccountVToken = (
     accountVToken.account = accountAddress.toHexString();
     accountVToken.market = marketAddress.toHexString();
     accountVToken.isCollateralOfUser = enteredMarket;
-    accountVToken.accrualBlockNumber = BigInt.fromI32(0);
+    accountVToken.accrualBlockNumber = zeroBigInt32;
     // we need to set an initial real onchain value to this otherwise it will never
     // be accurate
     const vTokenContract = VToken.bind(marketAddress);
@@ -92,9 +92,9 @@ export const getOrCreateAccountVToken = (
     accountVToken.userSupplyBalanceWei = suppliedAmountWei;
     accountVToken.userBorrowBalanceWei = borrowedAmountWei;
 
-    accountVToken.totalUnderlyingRedeemed = zeroBigDecimal;
+    accountVToken.totalUnderlyingRedeemedWei = zeroBigDecimal;
     accountVToken.accountBorrowIndex = zeroBigDecimal;
-    accountVToken.totalUnderlyingRepaid = zeroBigDecimal;
+    accountVToken.totalUnderlyingRepaidWei = zeroBigDecimal;
   }
   return accountVToken;
 };

--- a/subgraphs/isolated-pools/src/operations/update.ts
+++ b/subgraphs/isolated-pools/src/operations/update.ts
@@ -108,8 +108,9 @@ export const updateAccountVTokenTransferFrom = (
   exchangeRate: BigDecimal,
   underlyingDecimals: i32,
 ): AccountVToken => {
-  const amountUnderlying = exchangeRate.times(amount.toBigDecimal().div(vTokenDecimalsBigDecimal));
-  const amountUnderylingTruncated = amountUnderlying.truncate(underlyingDecimals);
+  const amountUnderlying = exchangeRate
+    .times(exponentToBigDecimal(underlyingDecimals))
+    .times(amount.toBigDecimal());
 
   const accountVToken = updateAccountVToken(
     marketAddress,
@@ -122,8 +123,8 @@ export const updateAccountVTokenTransferFrom = (
   );
   accountVToken.userSupplyBalanceWei = accountVToken.userSupplyBalanceWei.minus(amount);
 
-  accountVToken.totalUnderlyingRedeemed =
-    accountVToken.totalUnderlyingRedeemed.plus(amountUnderylingTruncated);
+  accountVToken.totalUnderlyingRedeemedWei =
+    accountVToken.totalUnderlyingRedeemedWei.plus(amountUnderlying);
   accountVToken.save();
   return accountVToken as AccountVToken;
 };

--- a/subgraphs/isolated-pools/tests/VToken/index.test.ts
+++ b/subgraphs/isolated-pools/tests/VToken/index.test.ts
@@ -552,8 +552,8 @@ describe('VToken', () => {
     assert.fieldEquals(
       'AccountVToken',
       accountVTokenId,
-      'totalUnderlyingRedeemed',
-      '53.37167017820446167',
+      'totalUnderlyingRedeemedWei',
+      '5337167017820446167010750000',
     );
   });
 

--- a/subgraphs/isolated-pools/tests/integration/pool.ts
+++ b/subgraphs/isolated-pools/tests/integration/pool.ts
@@ -182,9 +182,9 @@ describe('Pools', function () {
       expect(avt.transactions.length).to.equal(0);
       expect(avt.enteredMarket).to.equal(true);
       expect(avt.vTokenBalance).to.equal('0');
-      expect(avt.totalUnderlyingRedeemed).to.equal('0');
+      expect(avt.totalUnderlyingRedeemedWei).to.equal('0');
       expect(avt.accountBorrowIndex).to.equal('0');
-      expect(avt.totalUnderlyingRepaid).to.equal('0');
+      expect(avt.totalUnderlyingRepaidWei).to.equal('0');
       expect(avt.storedBorrowBalance).to.equal('0');
     });
 

--- a/subgraphs/isolated-pools/tests/integration/queries/accountFromMarket.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/accountFromMarket.graphql
@@ -13,9 +13,9 @@ query AccountFromMarket($marketId: ID!, $accountId: ID!){
       isCollateralOfUser
       userSupplyBalanceWei
       userBorrowBalanceWei
-      totalUnderlyingRedeemed
+      totalUnderlyingRedeemedWei
       accountBorrowIndex
-      totalUnderlyingRepaid
+      totalUnderlyingRepaidWei
     }
   }
 }

--- a/subgraphs/isolated-pools/tests/integration/queries/accountVTokens.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/accountVTokens.graphql
@@ -20,8 +20,8 @@ query AccountVTokens  {
     isCollateralOfUser
     userSupplyBalanceWei
     userBorrowBalanceWei
-    totalUnderlyingRedeemed
+    totalUnderlyingRedeemedWei
     accountBorrowIndex
-    totalUnderlyingRepaid
+    totalUnderlyingRepaidWei
   }
 }


### PR DESCRIPTION
## Jira ticket(s)

VEN-1057

## Changes
- Renamed totalUnderlyingRedeemed to totalUnderlyingRedeemedWei
- Renamed totalUnderlyingRepaid to totalUnderlyingRepaidWei
- Adjusted calculation to return wei instead of tokens