### PR TITLE
[VEN-842] feat: add reward distributor events

### DIFF
--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -62,6 +62,9 @@ type Pool @entity {
     maxAssets: BigInt!
     "Markets associated to this pool"
     markets: [Market!]! @derivedFrom(field: "pool")
+
+    "Reward distributors distributing rewards for markets in this pool"
+    rewardsDistributors: [RewardsDistributor!]! @derivedFrom(field: "pool")
 }
 
 """
@@ -270,4 +273,34 @@ type Transaction @entity {
     accountBorrows: BigDecimal
     "LIQUIATION: Underlying vToken amount that was repaid by liquidator"
     underlyingRepayAmount: BigDecimal
+}
+
+"""
+A interface for rewards distributor that distribute rewards to isolated pools
+"""
+type RewardsDistributor @entity {
+    "Address of the rewards distributor"
+    id: ID!
+    "Address of the pool"
+    pool: Pool!
+    "Address of the reward distributed"
+    reward: Bytes!
+    "Distribution rate for suppliers"
+    rewardSpeeds: [RewardSpeed!]! @derivedFrom(field:"rewardsDistributor")
+}
+
+"""
+A interface for rewards distributor that distribute rewards to isolated pools
+"""
+type RewardSpeed @entity {
+    "ID created from the reward distributor and market this speed applies to"
+    id: ID!
+    "Address of rewards distributor"
+    rewardsDistributor: RewardsDistributor!
+    "Address of the market this speed applies to"
+    market: Market!
+    "Distribution rate for borrowers"
+    borrowSpeedPerBlockWei: BigInt
+    "Distribution rate for suppliers"
+    supplySpeedPerBlockWei: BigInt
 }

--- a/subgraphs/isolated-pools/src/mappings/pool.ts
+++ b/subgraphs/isolated-pools/src/mappings/pool.ts
@@ -9,9 +9,12 @@ import {
   NewLiquidationThreshold,
   NewMinLiquidatableCollateral,
   NewPriceOracle,
+  NewRewardsDistributor,
   NewSupplyCap,
 } from '../../generated/PoolRegistry/Comptroller';
+import { RewardsDistributor as RewardsDistributorDataSource } from '../../generated/templates';
 import { defaultMantissaFactorBigDecimal } from '../constants';
+import { createRewardDistributor } from '../operations/create';
 import {
   getOrCreateAccount,
   getOrCreateAccountVTokenTransaction,
@@ -148,4 +151,9 @@ export function handleNewSupplyCap(event: NewSupplyCap): void {
   const market = getOrCreateMarket(vTokenAddress, poolAddress);
   market.supplyCapWei = newSupplyCap;
   market.save();
+}
+
+export function handleNewRewardsDistributor(event: NewRewardsDistributor): void {
+  RewardsDistributorDataSource.create(event.params.rewardsDistributor);
+  createRewardDistributor(event.params.rewardsDistributor, event.address);
 }

--- a/subgraphs/isolated-pools/src/mappings/rewardsDistributor.ts
+++ b/subgraphs/isolated-pools/src/mappings/rewardsDistributor.ts
@@ -1,0 +1,17 @@
+import {
+  RewardTokenBorrowSpeedUpdated,
+  RewardTokenSupplySpeedUpdated,
+} from '../../generated/templates/RewardsDistributor/RewardsDistributor';
+import { getOrCreateRewardSpeed } from '../operations/getOrCreate';
+
+export function handleRewardTokenBorrowSpeedUpdated(event: RewardTokenBorrowSpeedUpdated): void {
+  const rewardSpeed = getOrCreateRewardSpeed(event.address, event.params.vToken);
+  rewardSpeed.borrowSpeedPerBlockWei = event.params.newSpeed;
+  rewardSpeed.save();
+}
+
+export function handleRewardTokenSupplySpeedUpdated(event: RewardTokenSupplySpeedUpdated): void {
+  const rewardSpeed = getOrCreateRewardSpeed(event.address, event.params.vToken);
+  rewardSpeed.supplySpeedPerBlockWei = event.params.newSpeed;
+  rewardSpeed.save();
+}

--- a/subgraphs/isolated-pools/src/operations/create.ts
+++ b/subgraphs/isolated-pools/src/operations/create.ts
@@ -10,7 +10,15 @@ import {
   RepayBorrow,
   Transfer,
 } from '../../generated/PoolRegistry/VToken';
-import { Account, AccountVTokenBadDebt, Market, Pool, Transaction } from '../../generated/schema';
+import {
+  Account,
+  AccountVTokenBadDebt,
+  Market,
+  Pool,
+  RewardsDistributor,
+  Transaction,
+} from '../../generated/schema';
+import { RewardsDistributor as RewardDistributorContract } from '../../generated/templates/RewardsDistributor/RewardsDistributor';
 import { BEP20 as BEP20Contract } from '../../generated/templates/VToken/BEP20';
 import { VToken as VTokenContract } from '../../generated/templates/VToken/VToken';
 import {
@@ -37,6 +45,7 @@ import {
   getAccountVTokenId,
   getBadDebtEventId,
   getPoolId,
+  getRewardsDistributorId,
   getTransactionEventId,
 } from '../utilities/ids';
 
@@ -270,4 +279,17 @@ export const createAccountVTokenBadDebt = (
   accountVTokenBadDebt.amount = event.params.badDebtDelta;
   accountVTokenBadDebt.timestamp = event.block.timestamp;
   accountVTokenBadDebt.save();
+};
+
+export const createRewardDistributor = (
+  rewardsDistributorAddress: Address,
+  comptrollerAddress: Address,
+): void => {
+  const rewardDistributorContract = RewardDistributorContract.bind(rewardsDistributorAddress);
+  const rewardToken = rewardDistributorContract.rewardToken();
+  const id = getRewardsDistributorId(rewardsDistributorAddress);
+  const rewardsDistributor = new RewardsDistributor(id);
+  rewardsDistributor.pool = comptrollerAddress.toHexString();
+  rewardsDistributor.reward = rewardToken;
+  rewardsDistributor.save();
 };

--- a/subgraphs/isolated-pools/src/operations/getOrCreate.ts
+++ b/subgraphs/isolated-pools/src/operations/getOrCreate.ts
@@ -8,6 +8,7 @@ import {
   AccountVTokenTransaction,
   Market,
   Pool,
+  RewardSpeed,
 } from '../../generated/schema';
 import { zeroBigDecimal, zeroBigInt32 } from '../constants';
 import {
@@ -15,6 +16,7 @@ import {
   getAccountVTokenTransactionId,
   getMarketId,
   getPoolId,
+  getRewardSpeedId,
 } from '../utilities/ids';
 import { createAccount, createMarket, createPool } from './create';
 
@@ -105,4 +107,21 @@ export const getOrCreateAccountVToken = (
     accountVToken.totalUnderlyingRepaidWei = zeroBigDecimal;
   }
   return accountVToken;
+};
+
+export const getOrCreateRewardSpeed = (
+  rewardsDistributorAddress: Address,
+  marketAddress: Address,
+): RewardSpeed => {
+  const id = getRewardSpeedId(rewardsDistributorAddress, marketAddress);
+  let rewardSpeed = RewardSpeed.load(id);
+  if (!rewardSpeed) {
+    rewardSpeed = new RewardSpeed(id);
+    rewardSpeed.rewardsDistributor = rewardsDistributorAddress.toHexString();
+    rewardSpeed.market = marketAddress.toHexString();
+    rewardSpeed.borrowSpeedPerBlockWei = zeroBigInt32;
+    rewardSpeed.supplySpeedPerBlockWei = zeroBigInt32;
+    rewardSpeed.save();
+  }
+  return rewardSpeed;
 };

--- a/subgraphs/isolated-pools/src/utilities/ids.ts
+++ b/subgraphs/isolated-pools/src/utilities/ids.ts
@@ -36,3 +36,11 @@ export const getTransactionEventId = (
 
 export const getBadDebtEventId = (transactionHash: Bytes, transactionLogIndex: BigInt): string =>
   joinIds([transactionHash.toHexString(), transactionLogIndex.toString()]);
+
+export const getRewardsDistributorId = (rewardsDistributor: Address): string =>
+  joinIds([rewardsDistributor.toHexString()]);
+
+export const getRewardSpeedId = (
+  rewardsDistributorAddress: Address,
+  marketAddress: Address,
+): string => joinIds([rewardsDistributorAddress.toHexString(), marketAddress.toHexString()]);

--- a/subgraphs/isolated-pools/template.yaml
+++ b/subgraphs/isolated-pools/template.yaml
@@ -32,6 +32,8 @@ dataSources:
           file: ../../packages/isolated-pools-abis/Bep20.json
         - name: PoolLens
           file: ../../packages/isolated-pools-abis/PoolLens.json
+        - name: RewardsDistributor
+          file: ../../node_modules/@venusprotocol/isolated-pools/artifacts/contracts/Rewards/RewardsDistributor.sol/RewardsDistributor.json
       eventHandlers:
         - event: PoolRegistered(indexed address,(string,address,address,uint256,uint256))
           handler: handlePoolRegistered
@@ -92,6 +94,8 @@ templates:
           handler: handleNewMinLiquidatableCollateral
         - event: NewSupplyCap(indexed address,uint256)
           handler: handleNewSupplyCap
+        - event: NewRewardsDistributor(indexed address)
+          handler: handleNewRewardsDistributor
   - name: VToken
     kind: ethereum/contract
     network: {{ network }}
@@ -144,3 +148,24 @@ templates:
           handler: handleReservesAdded
         - event: ReservesReduced(address,uint256,uint256)
           handler: handleReservesReduced
+  - name: RewardsDistributor
+    kind: ethereum/contract
+    network: {{ network }}
+    source:
+      abi: RewardsDistributor
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/mappings/rewardsDistributor.ts
+      entities:
+        - RewardsDistributor
+        - AccountRewards
+      abis:
+        - name: RewardsDistributor
+          file: ../../node_modules/@venusprotocol/isolated-pools/artifacts/contracts/Rewards/RewardsDistributor.sol/RewardsDistributor.json
+      eventHandlers:
+        - event: RewardTokenBorrowSpeedUpdated(indexed address,uint256)
+          handler: handleRewardTokenBorrowSpeedUpdated
+        - event: RewardTokenSupplySpeedUpdated(indexed address,uint256)
+          handler: handleRewardTokenSupplySpeedUpdated

--- a/subgraphs/isolated-pools/tests/Pool/events.ts
+++ b/subgraphs/isolated-pools/tests/Pool/events.ts
@@ -11,6 +11,7 @@ import {
   NewLiquidationIncentive as NewLiquidationIncentiveEvent,
   NewMinLiquidatableCollateral as NewMinLiquidatableCollateralEvent,
   NewPriceOracle as NewPriceOracleEvent,
+  NewRewardsDistributor as NewRewardsDistributorEvent,
   NewSupplyCap as NewSupplyCapEvent,
 } from '../../generated/PoolRegistry/Comptroller';
 import { MarketAdded as MarketAddedEvent } from '../../generated/PoolRegistry/PoolRegistry';
@@ -246,6 +247,24 @@ export const createNewSupplyCapEvent = (
     ethereum.Value.fromUnsignedBigInt(newSupplyCap),
   );
   event.parameters.push(newSupplyCapParam);
+
+  return event;
+};
+
+export const createNewRewardsDistributor = (
+  comptrollerAddress: Address,
+  rewardsDistributor: Address,
+): NewRewardsDistributorEvent => {
+  const event = changetype<NewRewardsDistributorEvent>(newMockEvent());
+  event.address = comptrollerAddress;
+
+  event.parameters = [];
+
+  const rewardsDistributorParam = new ethereum.EventParam(
+    'rewardsDistributor',
+    ethereum.Value.fromAddress(rewardsDistributor),
+  );
+  event.parameters.push(rewardsDistributorParam);
 
   return event;
 };

--- a/subgraphs/isolated-pools/tests/RewardsDistributor/events.ts
+++ b/subgraphs/isolated-pools/tests/RewardsDistributor/events.ts
@@ -1,0 +1,43 @@
+import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts';
+import { newMockEvent } from 'matchstick-as';
+
+import {
+  RewardTokenBorrowSpeedUpdated as RewardTokenBorrowSpeedUpdatedEvent,
+  RewardTokenSupplySpeedUpdated as RewardTokenSupplySpeedUpdatedEvent,
+} from '../../generated/templates/RewardsDistributor/RewardsDistributor';
+
+export const createRewardTokenBorrowSpeedUpdatedEvent = (
+  rewardsDistributorAddress: Address,
+  vTokenAddress: Address,
+  newSpeed: BigInt,
+): RewardTokenBorrowSpeedUpdatedEvent => {
+  const event = changetype<RewardTokenBorrowSpeedUpdatedEvent>(newMockEvent());
+  event.address = rewardsDistributorAddress;
+  event.parameters = [];
+  const vTokenParam = new ethereum.EventParam('vToken', ethereum.Value.fromAddress(vTokenAddress));
+  event.parameters.push(vTokenParam);
+
+  const newSpeedValue = ethereum.Value.fromUnsignedBigInt(newSpeed);
+  const newSpeedParam = new ethereum.EventParam('newSpeed', newSpeedValue);
+  event.parameters.push(newSpeedParam);
+
+  return event;
+};
+
+export const createRewardTokenSupplySpeedUpdatedEvent = (
+  rewardsDistributorAddress: Address,
+  vTokenAddress: Address,
+  newSpeed: BigInt,
+): RewardTokenSupplySpeedUpdatedEvent => {
+  const event = changetype<RewardTokenSupplySpeedUpdatedEvent>(newMockEvent());
+  event.address = rewardsDistributorAddress;
+  event.parameters = [];
+  const vTokenParam = new ethereum.EventParam('vToken', ethereum.Value.fromAddress(vTokenAddress));
+  event.parameters.push(vTokenParam);
+
+  const newSpeedValue = ethereum.Value.fromUnsignedBigInt(newSpeed);
+  const newSpeedParam = new ethereum.EventParam('newSpeed', newSpeedValue);
+  event.parameters.push(newSpeedParam);
+
+  return event;
+};

--- a/subgraphs/isolated-pools/tests/RewardsDistributor/index.test.ts
+++ b/subgraphs/isolated-pools/tests/RewardsDistributor/index.test.ts
@@ -1,0 +1,109 @@
+import { Address, BigInt } from '@graphprotocol/graph-ts';
+import {
+  afterEach,
+  assert,
+  beforeEach,
+  clearStore,
+  describe,
+  test,
+} from 'matchstick-as/assembly/index';
+
+import { handleNewRewardsDistributor } from '../../src/mappings/pool';
+import {
+  handleRewardTokenBorrowSpeedUpdated,
+  handleRewardTokenSupplySpeedUpdated,
+} from '../../src/mappings/rewardsDistributor';
+import { getRewardSpeedId } from '../../src/utilities/ids';
+import { createNewRewardsDistributor } from '../Pool/events';
+import { createMarketMock } from '../VToken/mocks';
+import {
+  createRewardTokenBorrowSpeedUpdatedEvent,
+  createRewardTokenSupplySpeedUpdatedEvent,
+} from './events';
+import { createRewardsDistributorMock } from './mocks';
+
+const vTokenAddress = Address.fromString('0x0000000000000000000000000000000000000a0a');
+const comptrollerAddress = Address.fromString('0x0000000000000000000000000000000000000c0c');
+const rewardsDistributorAddress = Address.fromString('0x082F27894f3E3CbC2790899AEe82D6f149521AFa');
+const tokenAddress = Address.fromString('0x0000000000000000000000000000000000000b0b');
+
+const cleanup = (): void => {
+  clearStore();
+};
+
+beforeEach(() => {
+  createRewardsDistributorMock(rewardsDistributorAddress, tokenAddress);
+  const newRewardsDistributorEvent = createNewRewardsDistributor(
+    comptrollerAddress,
+    rewardsDistributorAddress,
+  );
+
+  handleNewRewardsDistributor(newRewardsDistributorEvent);
+  createMarketMock(vTokenAddress);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Rewards Distributor', () => {
+  test('indexes new borrow speed', () => {
+    const newBorrowRate = '6000000000';
+    const rewardTokenBorrowSpeedUpdatedEvent = createRewardTokenBorrowSpeedUpdatedEvent(
+      rewardsDistributorAddress,
+      vTokenAddress,
+      BigInt.fromString(newBorrowRate),
+    );
+
+    handleRewardTokenBorrowSpeedUpdated(rewardTokenBorrowSpeedUpdatedEvent);
+
+    const rewardId = getRewardSpeedId(rewardsDistributorAddress, vTokenAddress);
+    assert.fieldEquals('RewardSpeed', rewardId, 'id', rewardId);
+    assert.fieldEquals('RewardSpeed', rewardId, 'market', vTokenAddress.toHexString());
+    assert.fieldEquals(
+      'RewardSpeed',
+      rewardId,
+      'rewardsDistributor',
+      rewardsDistributorAddress.toHexString(),
+    );
+    assert.fieldEquals('RewardSpeed', rewardId, 'supplySpeedPerBlockWei', '0');
+    assert.fieldEquals('RewardSpeed', rewardId, 'borrowSpeedPerBlockWei', newBorrowRate);
+
+    assert.fieldEquals(
+      'RewardsDistributor',
+      rewardsDistributorAddress.toHex(),
+      'rewardSpeeds',
+      `[${rewardId}]`,
+    );
+  });
+
+  test('indexes new supply speed', () => {
+    const newSupplyRate = '7000000000';
+    const rewardTokenSupplySpeedUpdatedEvent = createRewardTokenSupplySpeedUpdatedEvent(
+      rewardsDistributorAddress,
+      vTokenAddress,
+      BigInt.fromString(newSupplyRate),
+    );
+
+    handleRewardTokenSupplySpeedUpdated(rewardTokenSupplySpeedUpdatedEvent);
+    const rewardId = getRewardSpeedId(rewardsDistributorAddress, vTokenAddress);
+
+    assert.fieldEquals('RewardSpeed', rewardId, 'id', rewardId);
+    assert.fieldEquals('RewardSpeed', rewardId, 'market', vTokenAddress.toHexString());
+    assert.fieldEquals(
+      'RewardSpeed',
+      rewardId,
+      'rewardsDistributor',
+      rewardsDistributorAddress.toHexString(),
+    );
+    assert.fieldEquals('RewardSpeed', rewardId, 'supplySpeedPerBlockWei', newSupplyRate);
+    assert.fieldEquals('RewardSpeed', rewardId, 'borrowSpeedPerBlockWei', '0');
+
+    assert.fieldEquals(
+      'RewardsDistributor',
+      rewardsDistributorAddress.toHex(),
+      'rewardSpeeds',
+      `[${rewardId}]`,
+    );
+  });
+});

--- a/subgraphs/isolated-pools/tests/RewardsDistributor/mocks.ts
+++ b/subgraphs/isolated-pools/tests/RewardsDistributor/mocks.ts
@@ -1,0 +1,27 @@
+import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts';
+import { createMockedFunction } from 'matchstick-as';
+
+export const createRewardsDistributorMock = (
+  rewardsDistributorAddress: Address,
+  rewardTokenAddress: Address,
+): void => {
+  createMockedFunction(rewardsDistributorAddress, 'rewardToken', 'rewardToken():(address)').returns(
+    [ethereum.Value.fromAddress(rewardTokenAddress)],
+  );
+
+  createMockedFunction(
+    rewardsDistributorAddress,
+    'rewardTokenBorrowSpeeds',
+    'rewardTokenBorrowSpeeds(address):(uint256)',
+  )
+    .withArgs([ethereum.Value.fromAddress(rewardTokenAddress)])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('40000000000'))]);
+
+  createMockedFunction(
+    rewardsDistributorAddress,
+    'rewardTokenSupplySpeeds',
+    'rewardTokenSupplySpeeds(address):(uint256)',
+  )
+    .withArgs([ethereum.Value.fromAddress(rewardTokenAddress)])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('30000000000'))]);
+};


### PR DESCRIPTION
Add events related to reward distributions.

Added events include
- NewRewardsDistributor(indexed address)
- RewardTokenBorrowSpeedUpdated(indexed address,uint256)
- RewardTokenSupplySpeedUpdated(indexed address,uint256)