### PR TITLE
refactor: log missing errors from getters

### DIFF
--- a/subgraphs/isolated-pools/src/mappings/pool.ts
+++ b/subgraphs/isolated-pools/src/mappings/pool.ts
@@ -12,7 +12,6 @@ import {
   NewSupplyCap,
 } from '../../generated/PoolRegistry/Comptroller';
 import { defaultMantissaFactorBigDecimal } from '../constants';
-import { getMarket } from '../operations/get';
 import {
   getOrCreateAccount,
   getOrCreateAccountVTokenTransaction,
@@ -26,10 +25,11 @@ import {
 import Box from '../utilities/box';
 
 export function handleMarketEntered(event: MarketEntered): void {
+  const poolAddress = event.address;
   const vTokenAddress = event.params.vToken;
   const accountAddress = event.params.account;
 
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress, poolAddress);
   getOrCreateAccount(accountAddress);
 
   updateOrCreateAccountVToken(
@@ -52,7 +52,7 @@ export function handleMarketExited(event: MarketExited): void {
   const vTokenAddress = event.params.vToken;
   const accountAddress = event.params.account;
 
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress);
   getOrCreateAccount(accountAddress);
 
   updateOrCreateAccountVToken(
@@ -84,7 +84,7 @@ export function handleNewCollateralFactor(event: NewCollateralFactor): void {
   const poolAddress = event.address;
   const vTokenAddress = event.params.vToken;
   const newCollateralFactorMantissa = event.params.newCollateralFactorMantissa;
-  const market = getOrCreateMarket(poolAddress, vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress, poolAddress);
   market.collateralFactor = newCollateralFactorMantissa
     .toBigDecimal()
     .div(defaultMantissaFactorBigDecimal);
@@ -94,7 +94,7 @@ export function handleNewCollateralFactor(event: NewCollateralFactor): void {
 export function handleNewLiquidationThreshold(event: NewLiquidationThreshold): void {
   const poolAddress = event.address;
   const vTokenAddress = event.params.vToken;
-  const market = getOrCreateMarket(poolAddress, vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress, poolAddress);
   market.liquidationThreshold = event.params.newLiquidationThresholdMantissa;
   market.save();
 }
@@ -125,9 +125,10 @@ export function handleActionPausedMarket(event: ActionPausedMarket): void {
 }
 
 export function handleNewBorrowCap(event: NewBorrowCap): void {
+  const poolAddress = event.address;
   const vTokenAddress = event.params.vToken;
   const borrowCap = event.params.newBorrowCap;
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress, poolAddress);
   market.borrowCapWei = borrowCap;
   market.save();
 }
@@ -136,16 +137,15 @@ export function handleNewMinLiquidatableCollateral(event: NewMinLiquidatableColl
   const poolAddress = event.address;
   const newMinLiquidatableCollateral = event.params.newMinLiquidatableCollateral;
   const pool = getOrCreatePool(poolAddress);
-  if (pool) {
-    pool.minLiquidatableCollateral = newMinLiquidatableCollateral;
-    pool.save();
-  }
+  pool.minLiquidatableCollateral = newMinLiquidatableCollateral;
+  pool.save();
 }
 
 export function handleNewSupplyCap(event: NewSupplyCap): void {
+  const poolAddress = event.address;
   const vTokenAddress = event.params.vToken;
   const newSupplyCap = event.params.newSupplyCap;
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress, poolAddress);
   market.supplyCapWei = newSupplyCap;
   market.save();
 }

--- a/subgraphs/isolated-pools/src/mappings/vToken.ts
+++ b/subgraphs/isolated-pools/src/mappings/vToken.ts
@@ -23,8 +23,7 @@ import {
   createRepayBorrowTransaction,
   createTransferTransaction,
 } from '../operations/create';
-import { getMarket } from '../operations/get';
-import { getOrCreateAccount } from '../operations/getOrCreate';
+import { getOrCreateAccount, getOrCreateMarket } from '../operations/getOrCreate';
 import {
   updateAccountVTokenBorrow,
   updateAccountVTokenRepayBorrow,
@@ -49,7 +48,7 @@ import {
  */
 export function handleMint(event: Mint): void {
   const vTokenAddress = event.address;
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress, null);
   createMintTransaction(event, market.underlyingDecimals);
 
   // we read the current total amount of supplied tokens by this account in the market
@@ -75,7 +74,7 @@ export function handleMint(event: Mint): void {
  */
 export function handleRedeem(event: Redeem): void {
   const vTokenAddress = event.address;
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress);
   createRedeemTransaction(event, market.underlyingDecimals);
 
   // we read the account's balance and...
@@ -98,7 +97,7 @@ export function handleRedeem(event: Redeem): void {
  */
 export function handleBorrow(event: Borrow): void {
   const vTokenAddress = event.address;
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress);
 
   updateAccountVTokenBorrow(
     vTokenAddress,
@@ -138,7 +137,7 @@ export function handleBorrow(event: Borrow): void {
  */
 export function handleRepayBorrow(event: RepayBorrow): void {
   const vTokenAddress = event.address;
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress);
 
   updateAccountVTokenRepayBorrow(
     vTokenAddress,
@@ -179,7 +178,7 @@ export function handleRepayBorrow(event: RepayBorrow): void {
  */
 export function handleLiquidateBorrow(event: LiquidateBorrow): void {
   const vTokenAddress = event.address;
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress);
   const liquidator = getOrCreateAccount(event.params.liquidator);
   liquidator.countLiquidator = liquidator.countLiquidator + 1;
   liquidator.save();
@@ -197,7 +196,7 @@ export function handleAccrueInterest(event: AccrueInterest): void {
 
 export function handleNewReserveFactor(event: NewReserveFactor): void {
   const vTokenAddress = event.address;
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress);
   market.reserveFactor = event.params.newReserveFactorMantissa;
   market.save();
 }
@@ -222,7 +221,7 @@ export function handleTransfer(event: Transfer): void {
   const accountFromAddress = event.params.from;
   const accountToAddress = event.params.to;
 
-  let market = getMarket(vTokenAddress);
+  let market = getOrCreateMarket(vTokenAddress);
   // We only updateMarket() if accrual block number is not up to date. This will only happen
   // with normal transfers, since mint, redeem, and seize transfers will already run updateMarket()
   if (market.accrualBlockNumber != event.block.number.toI32()) {
@@ -272,14 +271,14 @@ export function handleTransfer(event: Transfer): void {
 
 export function handleNewMarketInterestRateModel(event: NewMarketInterestRateModel): void {
   const vTokenAddress = event.address;
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress);
   market.interestRateModelAddress = event.params.newInterestRateModel;
   market.save();
 }
 
 export function handleBadDebtIncreased(event: BadDebtIncreased): void {
   const vTokenAddress = event.address;
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress);
   market.badDebtWei = event.params.badDebtNew;
   market.save();
 
@@ -288,21 +287,21 @@ export function handleBadDebtIncreased(event: BadDebtIncreased): void {
 
 export function handleNewAccessControlManager(event: NewAccessControlManager): void {
   const vTokenAddress = event.address;
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress);
   market.accessControlManager = event.params.newAccessControlManager;
   market.save();
 }
 
 export function handleReservesAdded(event: ReservesAdded): void {
   const vTokenAddress = event.address;
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress);
   market.reservesWei = event.params.newTotalReserves;
   market.save();
 }
 
 export function handleReservesReduced(event: ReservesReduced): void {
   const vTokenAddress = event.address;
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress);
   market.reservesWei = event.params.newTotalReserves;
   market.save();
 }

--- a/subgraphs/isolated-pools/src/operations/get.ts
+++ b/subgraphs/isolated-pools/src/operations/get.ts
@@ -3,7 +3,7 @@ import { Address, log } from '@graphprotocol/graph-ts';
 import { Market, Pool } from '../../generated/schema';
 import { getMarketId } from '../utilities/ids';
 
-export const getPool = (comptroller: Address): Pool => {
+export const getPool = (comptroller: Address): Pool | null => {
   const pool = Pool.load(comptroller.toHexString());
   if (!pool) {
     log.error('Pool {} not found', [comptroller.toString()]);
@@ -11,11 +11,11 @@ export const getPool = (comptroller: Address): Pool => {
   return pool as Pool;
 };
 
-export const getMarket = (vTokenAddress: Address): Market => {
+export const getMarket = (vTokenAddress: Address): Market | null => {
   const id = getMarketId(vTokenAddress);
   const market = Market.load(id);
   if (!market) {
     log.error('Market {} not found', [id]);
   }
-  return market as Market;
+  return market;
 };

--- a/subgraphs/isolated-pools/src/operations/get.ts
+++ b/subgraphs/isolated-pools/src/operations/get.ts
@@ -3,19 +3,19 @@ import { Address, log } from '@graphprotocol/graph-ts';
 import { Market, Pool } from '../../generated/schema';
 import { getMarketId } from '../utilities/ids';
 
-export const getPool = (comptroller: Address): Pool | null => {
+export const getPool = (comptroller: Address): Pool => {
   const pool = Pool.load(comptroller.toHexString());
   if (!pool) {
-    log.warning('Pool {} not found', [comptroller.toString()]);
+    log.error('Pool {} not found', [comptroller.toString()]);
   }
-  return pool;
+  return pool as Pool;
 };
 
 export const getMarket = (vTokenAddress: Address): Market => {
   const id = getMarketId(vTokenAddress);
   const market = Market.load(id);
   if (!market) {
-    log.warning('Market {} not found', [id]);
+    log.error('Market {} not found', [id]);
   }
   return market as Market;
 };

--- a/subgraphs/isolated-pools/src/operations/getOrCreate.ts
+++ b/subgraphs/isolated-pools/src/operations/getOrCreate.ts
@@ -1,6 +1,7 @@
 import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts';
 
 import { VToken } from '../../generated/PoolRegistry/VToken';
+import { VToken as VTokenContract } from '../../generated/PoolRegistry/VToken';
 import {
   Account,
   AccountVToken,
@@ -17,10 +18,17 @@ import {
 } from '../utilities/ids';
 import { createAccount, createMarket, createPool } from './create';
 
-export const getOrCreateMarket = (comptroller: Address, vTokenAddress: Address): Market => {
+export const getOrCreateMarket = (
+  vTokenAddress: Address,
+  comptrollerAddress: Address | null = null,
+): Market => {
   let market = Market.load(getMarketId(vTokenAddress));
   if (!market) {
-    market = createMarket(comptroller, vTokenAddress);
+    const vTokenContract = VTokenContract.bind(vTokenAddress);
+    if (!comptrollerAddress) {
+      comptrollerAddress = vTokenContract.comptroller();
+    }
+    market = createMarket(comptrollerAddress, vTokenAddress);
   }
   return market;
 };

--- a/subgraphs/isolated-pools/src/operations/update.ts
+++ b/subgraphs/isolated-pools/src/operations/update.ts
@@ -13,7 +13,7 @@ import {
 import { vBnbAddress } from '../constants/addresses';
 import { exponentToBigDecimal } from '../utilities';
 import { getBnbPriceInUsd, getTokenPriceInUsd } from '../utilities';
-import { getMarket } from './get';
+import { getOrCreateMarket } from './getOrCreate';
 import {
   getOrCreateAccount,
   getOrCreateAccountVToken,
@@ -160,7 +160,7 @@ export const updateMarket = (
   blockNumber: i32,
   blockTimestamp: i32,
 ): Market => {
-  const market = getMarket(vTokenAddress);
+  const market = getOrCreateMarket(vTokenAddress);
 
   // Only updateMarket if it has not been updated this block
   if (market.accrualBlockNumber === blockNumber) {

--- a/subgraphs/isolated-pools/tests/VToken/index.test.ts
+++ b/subgraphs/isolated-pools/tests/VToken/index.test.ts
@@ -137,6 +137,10 @@ describe('VToken', () => {
       accountBalance,
     );
     const market = getMarket(aaaTokenAddress);
+    assert.assertNotNull(market);
+    if (!market) {
+      return;
+    }
 
     handleMint(mintEvent);
     const id = getTransactionEventId(mintEvent.transaction.hash, mintEvent.transactionLogIndex);
@@ -177,6 +181,10 @@ describe('VToken', () => {
       accountBalance,
     );
     const market = getMarket(aaaTokenAddress);
+    assert.assertNotNull(market);
+    if (!market) {
+      return;
+    }
 
     handleRedeem(redeemEvent);
     const id = getTransactionEventId(redeemEvent.transaction.hash, redeemEvent.transactionLogIndex);
@@ -242,6 +250,10 @@ describe('VToken', () => {
     );
     const accountVTokenId = getAccountVTokenId(aaaTokenAddress, borrower);
     const market = getMarket(aaaTokenAddress);
+    assert.assertNotNull(market);
+    if (!market) {
+      return;
+    }
 
     assert.fieldEquals('Transaction', transactionId, 'id', transactionId);
     assert.fieldEquals('Transaction', transactionId, 'type', BORROW);
@@ -321,6 +333,10 @@ describe('VToken', () => {
     );
     const accountVTokenId = getAccountVTokenId(aaaTokenAddress, borrower);
     const market = getMarket(aaaTokenAddress);
+    assert.assertNotNull(market);
+    if (!market) {
+      return;
+    }
 
     assert.fieldEquals('Transaction', transactionId, 'id', transactionId);
     assert.fieldEquals('Transaction', transactionId, 'type', REPAY);
@@ -390,6 +406,10 @@ describe('VToken', () => {
       liquidateBorrowEvent.transactionLogIndex,
     );
     const market = getMarket(aaaTokenAddress);
+    assert.assertNotNull(market);
+    if (!market) {
+      return;
+    }
 
     const underlyingDecimals = market.underlyingDecimals;
     const underlyingRepayAmount = liquidateBorrowEvent.params.repayAmount
@@ -760,6 +780,10 @@ describe('VToken', () => {
 
   test('registers increase and decrease in the market supplier count', () => {
     const market = getMarket(aaaTokenAddress);
+    assert.assertNotNull(market);
+    if (!market) {
+      return;
+    }
     assert.fieldEquals('Market', market.id, 'supplierCount', '0');
 
     const actualMintAmount = BigInt.fromI64(12);
@@ -833,6 +857,10 @@ describe('VToken', () => {
 
   test('registers increase and decrease in the market borrower count', () => {
     const market = getMarket(aaaTokenAddress);
+    assert.assertNotNull(market);
+    if (!market) {
+      return;
+    }
     assert.fieldEquals('Market', market.id, 'borrowerCount', '0');
 
     const borrowAmount = BigInt.fromI64(10);


### PR DESCRIPTION
Getters are for situations where we don't want to silently create an entity because if we missed the entity something went wrong. Because of this getters shouldn't fail silently, they should throw an error when they fail to get the entity so that the issue can be raised and investigated

Edit: While the above is true, taking down the subgraph may be extreme and a better choice is to log and monitor for errors. This will allow the fix to index in the background without breaking the current version. Updated getters to log an error.