### PR TITLE
[VEN-1063] Fetching initial market values upon creation

### DIFF
--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -94,7 +94,7 @@ type Market @entity {
     "The vToken contract balance of BEP20 or BNB"
     cash: BigDecimal!
     "Collateral factor determining how much one can borrow"
-    collateralFactor: BigDecimal!
+    collateralFactorMantissa: BigInt!
     "Exchange rate of tokens / vTokens"
     exchangeRate:  BigDecimal!
     "Address of the interest rate model"
@@ -111,8 +111,6 @@ type Market @entity {
     underlyingAddress: Bytes!
     "Underlying token name"
     underlyingName: String!
-    "Underlying price of token in BNB (ex. 0.007 DAI)"
-    underlyingPrice: BigDecimal!
     "Underlying token symbol"
     underlyingSymbol: String!
     "Max token borrow amount allowed"

--- a/subgraphs/isolated-pools/src/mappings/pool.ts
+++ b/subgraphs/isolated-pools/src/mappings/pool.ts
@@ -13,7 +13,6 @@ import {
   NewSupplyCap,
 } from '../../generated/PoolRegistry/Comptroller';
 import { RewardsDistributor as RewardsDistributorDataSource } from '../../generated/templates';
-import { defaultMantissaFactorBigDecimal } from '../constants';
 import { createRewardDistributor } from '../operations/create';
 import {
   getOrCreateAccount,
@@ -88,9 +87,8 @@ export function handleNewCollateralFactor(event: NewCollateralFactor): void {
   const vTokenAddress = event.params.vToken;
   const newCollateralFactorMantissa = event.params.newCollateralFactorMantissa;
   const market = getOrCreateMarket(vTokenAddress, poolAddress);
-  market.collateralFactor = newCollateralFactorMantissa
-    .toBigDecimal()
-    .div(defaultMantissaFactorBigDecimal);
+  market.collateralFactorMantissa = newCollateralFactorMantissa;
+
   market.save();
 }
 

--- a/subgraphs/isolated-pools/src/mappings/poolRegistry.ts
+++ b/subgraphs/isolated-pools/src/mappings/poolRegistry.ts
@@ -35,7 +35,7 @@ export function handleMarketAdded(event: MarketAdded): void {
   const vTokenAddress = event.params.vTokenAddress;
   const comptroller = event.params.comptroller;
   VTokenDataSource.create(vTokenAddress);
-  createMarket(comptroller, vTokenAddress);
+  createMarket(comptroller, vTokenAddress, event.block.timestamp);
 }
 
 export function handlePoolMetadataUpdated(event: PoolMetadataUpdated): void {

--- a/subgraphs/isolated-pools/src/operations/getOrCreate.ts
+++ b/subgraphs/isolated-pools/src/operations/getOrCreate.ts
@@ -23,6 +23,7 @@ import { createAccount, createMarket, createPool } from './create';
 export const getOrCreateMarket = (
   vTokenAddress: Address,
   comptrollerAddress: Address | null = null,
+  blockTimestamp: BigInt = BigInt.fromI32(0),
 ): Market => {
   let market = Market.load(getMarketId(vTokenAddress));
   if (!market) {
@@ -30,7 +31,7 @@ export const getOrCreateMarket = (
     if (!comptrollerAddress) {
       comptrollerAddress = vTokenContract.comptroller();
     }
-    market = createMarket(comptrollerAddress, vTokenAddress);
+    market = createMarket(comptrollerAddress, vTokenAddress, blockTimestamp);
   }
   return market;
 };

--- a/subgraphs/isolated-pools/src/operations/update.ts
+++ b/subgraphs/isolated-pools/src/operations/update.ts
@@ -172,7 +172,7 @@ export const updateMarket = (
     vTokenAddress,
     market.underlyingDecimals,
   );
-  market.underlyingPrice = tokenPriceUsd.truncate(market.underlyingDecimals);
+  market.underlyingPriceUsd = tokenPriceUsd.truncate(market.underlyingDecimals);
 
   market.accrualBlockNumber = marketContract.accrualBlockNumber().toI32();
   market.blockTimestamp = blockTimestamp;

--- a/subgraphs/isolated-pools/tests/Pool/index.test.ts
+++ b/subgraphs/isolated-pools/tests/Pool/index.test.ts
@@ -10,7 +10,7 @@ import {
   test,
 } from 'matchstick-as/assembly';
 
-import { defaultMantissaFactorBigDecimal, oneBigInt, zeroBigInt32 } from '../../src/constants';
+import { oneBigInt, zeroBigInt32 } from '../../src/constants';
 import {
   handleActionPausedMarket,
   handleMarketEntered,
@@ -60,6 +60,8 @@ const interestRateModelAddress = Address.fromString('0x594942C0e62eC577889777424
 
 const rewardsDistributorAddress = Address.fromString('0x082F27894f3E3CbC2790899AEe82D6f149521AFa');
 
+const underlyingPrice = BigInt.fromString('15000000000000000');
+
 const cleanup = (): void => {
   clearStore();
 };
@@ -75,6 +77,7 @@ beforeAll(() => {
     BigInt.fromI32(18),
     balanceOfAccount,
     interestRateModelAddress,
+    underlyingPrice,
   );
 
   createMockedFunction(
@@ -233,10 +236,7 @@ describe('Pool Events', () => {
     };
 
     assertMarketDocument('id', vTokenAddress.toHexString());
-    assertMarketDocument(
-      'collateralFactor',
-      newCollateralFactorMantissa.toBigDecimal().div(defaultMantissaFactorBigDecimal).toString(),
-    );
+    assertMarketDocument('collateralFactorMantissa', newCollateralFactorMantissa.toString());
   });
 
   test('indexes NewLiquidationIncentive event', () => {

--- a/subgraphs/isolated-pools/tests/VToken/index.test.ts
+++ b/subgraphs/isolated-pools/tests/VToken/index.test.ts
@@ -70,6 +70,8 @@ const aaaTokenAddress = Address.fromString('0x0000000000000000000000000000000000
 
 const interestRateModelAddress = Address.fromString('0x594942C0e62eC577889777424CD367545C796A74');
 
+const underlyingPrice = BigInt.fromString('15000000000000000');
+
 const cleanup = (): void => {
   clearStore();
 };
@@ -84,6 +86,7 @@ beforeAll(() => {
     BigInt.fromI32(18),
     BigInt.fromI32(100),
     interestRateModelAddress,
+    underlyingPrice,
   );
 
   createMarketMock(aaaTokenAddress);

--- a/subgraphs/isolated-pools/tests/VToken/mocks.ts
+++ b/subgraphs/isolated-pools/tests/VToken/mocks.ts
@@ -68,6 +68,7 @@ export const createVBep20AndUnderlyingMock = (
   decimals: BigInt,
   reserveFactorMantissa: BigInt,
   interestRateModelAddress: Address,
+  underlyingPrice: BigInt,
 ): void => {
   // vBep20
   createMockedFunction(contractAddress, 'underlying', 'underlying():(address)').returns([
@@ -108,6 +109,64 @@ export const createVBep20AndUnderlyingMock = (
   createMockedFunction(underlyingAddress, 'symbol', 'symbol():(string)').returns([
     ethereum.Value.fromString(symbol),
   ]);
+  createMockedFunction(
+    priceOracleAddress,
+    'getUnderlyingPrice',
+    'getUnderlyingPrice(address):(uint256)',
+  )
+    .withArgs([ethereum.Value.fromAddress(contractAddress)])
+    .returns([ethereum.Value.fromUnsignedBigInt(underlyingPrice)]);
+  createMockedFunction(
+    contractAddress,
+    'borrowRatePerBlock',
+    'borrowRatePerBlock():(uint256)',
+  ).returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('0'))]);
+  createMockedFunction(contractAddress, 'getCash', 'getCash():(uint256)').returns([
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromString('0')),
+  ]);
+  createMockedFunction(
+    contractAddress,
+    'exchangeRateStored',
+    'exchangeRateStored():(uint256)',
+  ).returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('0'))]);
+  createMockedFunction(contractAddress, 'badDebt', 'badDebt():(uint256)').returns([
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromString('0')),
+  ]);
+  createMockedFunction(contractAddress, 'totalSupply', 'totalSupply():(uint256)').returns([
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromString('36504567163409')),
+  ]);
+  createMockedFunction(contractAddress, 'totalBorrows', 'totalBorrows():(uint256)').returns([
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromString('36504567163409')),
+  ]);
+  createMockedFunction(contractAddress, 'totalReserves', 'totalReserves():(uint256)').returns([
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromString('0')),
+  ]);
+  createMockedFunction(
+    contractAddress,
+    'accrualBlockNumber',
+    'accrualBlockNumber():(uint256)',
+  ).returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('0'))]);
+  createMockedFunction(contractAddress, 'borrowIndex', 'borrowIndex():(uint256)').returns([
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromString('0')),
+  ]);
+  createMockedFunction(
+    contractAddress,
+    'supplyRatePerBlock',
+    'supplyRatePerBlock():(uint256)',
+  ).returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('0'))]);
+  createMockedFunction(comptrollerAddress, 'supplyCaps', 'supplyCaps(address):(uint256)')
+    .withArgs([ethereum.Value.fromAddress(contractAddress)])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('0'))]);
+  createMockedFunction(comptrollerAddress, 'borrowCaps', 'borrowCaps(address):(uint256)')
+    .withArgs([ethereum.Value.fromAddress(contractAddress)])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('0'))]);
+  createMockedFunction(comptrollerAddress, 'markets', 'markets(address):(bool,uint256,uint256)')
+    .withArgs([ethereum.Value.fromAddress(contractAddress)])
+    .returns([
+      ethereum.Value.fromBoolean(true),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString('0')),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString('0')),
+    ]);
 };
 
 export const createMarketMock = (marketAddress: Address): void => {

--- a/subgraphs/isolated-pools/tests/integration/pool.ts
+++ b/subgraphs/isolated-pools/tests/integration/pool.ts
@@ -127,7 +127,7 @@ describe('Pools', function () {
       expect(m.pool.id).to.equal(pool.id);
       expect(m.borrowRate).to.equal('0');
       expect(m.cash).to.equal('0');
-      expect(m.collateralFactor).to.equal('0');
+      expect(m.collateralFactorMantissa).to.equal('0');
       expect(m.exchangeRate).to.equal('0');
       expect(m.interestRateModelAddress).to.equal(interestRateModelAddresses[idx]);
       expect(m.name).to.equal(marketNames[idx]);
@@ -238,7 +238,7 @@ describe('Pools', function () {
     const { markets: marketsBeforeEvent } = dataBeforeEvent!;
 
     marketsBeforeEvent.forEach(m => {
-      expect(m.collateralFactor).to.equal('0');
+      expect(m.collateralFactorMantissa).to.equal('0');
     });
 
     const eventPromises = marketsBeforeEvent.map(async m => {
@@ -260,7 +260,7 @@ describe('Pools', function () {
     const { markets } = data!;
 
     markets.forEach(m => {
-      expect(m.collateralFactor).to.equal('0.1');
+      expect(m.collateralFactorMantissa).to.equal('0.1');
     });
   });
 


### PR DESCRIPTION
## Jira ticket(s)

VEN-1063

## Changes

Markets used to have zeroed values as defaults once created. Now when indexing the creation event we will read the needed values using smart contract calls.