### PR TITLE
fix: rename isCollateralOfUser to match contract

### DIFF
--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -195,7 +195,7 @@ type AccountVToken @entity {
     "Current borrow balance stored in contract (exclusive of interest since accrualBlockNumber)"
     userBorrowBalanceWei: BigInt!
     "True if user is entered, false if they are exited"
-    isCollateralOfUser: Boolean!
+    enteredMarket: Boolean!
 
     "Total amount of underling redeemed"
     totalUnderlyingRedeemedWei: BigDecimal!

--- a/subgraphs/isolated-pools/src/operations/getOrCreate.ts
+++ b/subgraphs/isolated-pools/src/operations/getOrCreate.ts
@@ -92,7 +92,7 @@ export const getOrCreateAccountVToken = (
     accountVToken.symbol = marketSymbol;
     accountVToken.account = accountAddress.toHexString();
     accountVToken.market = marketAddress.toHexString();
-    accountVToken.isCollateralOfUser = enteredMarket;
+    accountVToken.enteredMarket = enteredMarket;
     accountVToken.accrualBlockNumber = zeroBigInt32;
     // we need to set an initial real onchain value to this otherwise it will never
     // be accurate

--- a/subgraphs/isolated-pools/tests/Pool/index.test.ts
+++ b/subgraphs/isolated-pools/tests/Pool/index.test.ts
@@ -152,7 +152,7 @@ describe('Pool Events', () => {
       accountVTokenTransactionId,
     );
     assert.fieldEquals('AccountVToken', accountVTokenId, 'id', accountVTokenId);
-    assert.fieldEquals('AccountVToken', accountVTokenId, 'isCollateralOfUser', 'true');
+    assert.fieldEquals('AccountVToken', accountVTokenId, 'enteredMarket', 'true');
     assert.fieldEquals(
       'AccountVToken',
       accountVTokenId,
@@ -185,7 +185,7 @@ describe('Pool Events', () => {
       accountVTokenTransactionId,
     );
     assert.fieldEquals('AccountVToken', accountVTokenId, 'id', accountVTokenId);
-    assert.fieldEquals('AccountVToken', accountVTokenId, 'isCollateralOfUser', 'false');
+    assert.fieldEquals('AccountVToken', accountVTokenId, 'enteredMarket', 'false');
     assert.fieldEquals(
       'AccountVToken',
       accountVTokenId,

--- a/subgraphs/isolated-pools/tests/integration/queries/accountFromMarket.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/accountFromMarket.graphql
@@ -10,7 +10,7 @@ query AccountFromMarket($marketId: ID!, $accountId: ID!){
         timestamp
         block
       }
-      isCollateralOfUser
+      enteredMarket
       userSupplyBalanceWei
       userBorrowBalanceWei
       totalUnderlyingRedeemedWei

--- a/subgraphs/isolated-pools/tests/integration/queries/accountVTokens.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/accountVTokens.graphql
@@ -17,7 +17,7 @@ query AccountVTokens  {
       timestamp
       block
     }
-    isCollateralOfUser
+    enteredMarket
     userSupplyBalanceWei
     userBorrowBalanceWei
     totalUnderlyingRedeemedWei


### PR DESCRIPTION
Renames `isCollateralOfUser` back to `enteredMarket` to match the contract interface