### PR TITLE
[VEN-1087] Refactored priceOracleAddress and removed pauseGuardianAddress

### DIFF
--- a/subgraphs/isolated-pools/src/constants/addresses.ts
+++ b/subgraphs/isolated-pools/src/constants/addresses.ts
@@ -10,7 +10,3 @@ export const poolRegistryAddress = Address.fromString(poolRegistryAddressString)
 export const poolLensAddress = Address.fromString(poolLensAddressString);
 
 export const priceOracleAddress = Address.fromString('0xb0b0000000000000000000000000000000000000');
-
-export const pauseGuardianAddress = Address.fromString(
-  '0xd0d0000000000000000000000000000000000000',
-);

--- a/subgraphs/isolated-pools/src/constants/addresses.ts
+++ b/subgraphs/isolated-pools/src/constants/addresses.ts
@@ -8,5 +8,3 @@ import {
 export const poolRegistryAddress = Address.fromString(poolRegistryAddressString);
 
 export const poolLensAddress = Address.fromString(poolLensAddressString);
-
-export const priceOracleAddress = Address.fromString('0xb0b0000000000000000000000000000000000000');

--- a/subgraphs/isolated-pools/tests/PoolRegistry/index.test.ts
+++ b/subgraphs/isolated-pools/tests/PoolRegistry/index.test.ts
@@ -8,9 +8,8 @@ import {
   test,
 } from 'matchstick-as/assembly/index';
 
-import { priceOracleAddress } from '../../src/constants/addresses';
 import { handlePoolNameSet, handlePoolRegistered } from '../../src/mappings/poolRegistry';
-import { createPoolRegistryMock } from '../VToken/mocks';
+import { createPoolRegistryMock, mockPriceOracleAddress } from '../VToken/mocks';
 import { createPoolNameSetEvent, createPoolRegisteredEvent } from './events';
 
 const cleanup = (): void => {
@@ -65,7 +64,7 @@ describe('Pool Registry', () => {
     assertPoolDocument('category', 'Games');
     assertPoolDocument('logoUrl', '/logo.png');
     assertPoolDocument('description', 'Game related tokens');
-    assertPoolDocument('priceOracle', priceOracleAddress.toHex());
+    assertPoolDocument('priceOracle', mockPriceOracleAddress.toHex());
     assertPoolDocument('closeFactor', '5');
     assertPoolDocument('liquidationIncentive', '7');
     assertPoolDocument('maxAssets', '10');

--- a/subgraphs/isolated-pools/tests/VToken/mocks.ts
+++ b/subgraphs/isolated-pools/tests/VToken/mocks.ts
@@ -1,11 +1,11 @@
 import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts';
 import { createMockedFunction } from 'matchstick-as';
 
-import {
-  poolLensAddress,
-  poolRegistryAddress,
-  priceOracleAddress,
-} from '../../src/constants/addresses';
+import { poolLensAddress, poolRegistryAddress } from '../../src/constants/addresses';
+
+export const mockPriceOracleAddress = Address.fromString(
+  '0xb0b0000000000000000000000000000000000000',
+);
 
 // type PoolsArray = [name: string, creator: Address, comptroller: Address, blockPosted: BigInt, timestampPosted: BigInt][];
 export const createPoolRegistryMock = (pools: Array<Array<ethereum.Value>>): void => {
@@ -39,7 +39,7 @@ export const createPoolRegistryMock = (pools: Array<Array<ethereum.Value>>): voi
       ethereum.Value.fromString('Games'), // category
       ethereum.Value.fromString('/logo.png'), // logoURL
       ethereum.Value.fromString('Game related tokens'), // description
-      ethereum.Value.fromAddress(priceOracleAddress), // priceOracle
+      ethereum.Value.fromAddress(mockPriceOracleAddress), // priceOracle
       ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(5)), // closeFactor
       ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(7)), // liquidationIncentive
       ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(6)), // minLiquidatableCollateral
@@ -110,7 +110,7 @@ export const createVBep20AndUnderlyingMock = (
     ethereum.Value.fromString(symbol),
   ]);
   createMockedFunction(
-    priceOracleAddress,
+    mockPriceOracleAddress,
     'getUnderlyingPrice',
     'getUnderlyingPrice(address):(uint256)',
   )
@@ -219,7 +219,7 @@ export const createMarketMock = (marketAddress: Address): void => {
 export const createPriceOracleMock = (tokens: Array<Array<ethereum.Value>>): void => {
   tokens.forEach((token): void => {
     createMockedFunction(
-      priceOracleAddress,
+      mockPriceOracleAddress,
       'getUnderlyingPrice',
       'getUnderlyingPrice(address):(uint256)',
     )


### PR DESCRIPTION
## Jira ticket(s)

VEN-1087

## Changes
- Turned `priceOracleAddress` into `mockPriceOracleAddress`, as it was only being used during tests
- Removed `pauseGuardianAddress` as it was not being used anywhere