### PR TITLE
[VEN-1085] Removed unused props from updateAccountVTokenBorrow & updateAccountVTokenRepayBorrow

### DIFF
--- a/subgraphs/isolated-pools/src/mappings/vToken.ts
+++ b/subgraphs/isolated-pools/src/mappings/vToken.ts
@@ -107,7 +107,6 @@ export function handleBorrow(event: Borrow): void {
     event.block.timestamp,
     event.block.number,
     event.logIndex,
-    event.params.borrowAmount,
     event.params.accountBorrows,
     market.borrowIndex,
   );
@@ -147,7 +146,6 @@ export function handleRepayBorrow(event: RepayBorrow): void {
     event.block.timestamp,
     event.block.number,
     event.logIndex,
-    event.params.repayAmount,
     event.params.accountBorrows,
     market.borrowIndex,
   );

--- a/subgraphs/isolated-pools/src/operations/update.ts
+++ b/subgraphs/isolated-pools/src/operations/update.ts
@@ -49,7 +49,6 @@ export const updateAccountVTokenBorrow = (
   timestamp: BigInt,
   blockNumber: BigInt,
   logIndex: BigInt,
-  borrowAmount: BigInt,
   accountBorrows: BigInt,
   borrowIndex: BigDecimal,
 ): AccountVToken => {
@@ -76,7 +75,6 @@ export const updateAccountVTokenRepayBorrow = (
   timestamp: BigInt,
   blockNumber: BigInt,
   logIndex: BigInt,
-  repayAmount: BigInt,
   accountBorrows: BigInt,
   borrowIndex: BigDecimal,
 ): AccountVToken => {


### PR DESCRIPTION
## Jira ticket(s)

VEN-1085

## Changes
- Removed unused props from functions `updateAccountVTokenBorrow` and `updateAccountVTokenRepayBorrow`