### PR TITLE
[VEN-1084] Renamed user fields to account fields in AccountVToken entity

### DIFF
--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -191,9 +191,9 @@ type AccountVToken @entity {
     accrualBlockNumber: BigInt!
     
     "Amount of tokens supplied to the market"
-    userSupplyBalanceWei: BigInt!
+    accountSupplyBalanceWei: BigInt!
     "Current borrow balance stored in contract (exclusive of interest since accrualBlockNumber)"
-    userBorrowBalanceWei: BigInt!
+    accountBorrowBalanceWei: BigInt!
     "True if user is entered, false if they are exited"
     enteredMarket: Boolean!
 

--- a/subgraphs/isolated-pools/src/operations/getOrCreate.ts
+++ b/subgraphs/isolated-pools/src/operations/getOrCreate.ts
@@ -100,8 +100,8 @@ export const getOrCreateAccountVToken = (
     const accountSnapshot = vTokenContract.getAccountSnapshot(accountAddress);
     const suppliedAmountWei = accountSnapshot.value1;
     const borrowedAmountWei = accountSnapshot.value2;
-    accountVToken.userSupplyBalanceWei = suppliedAmountWei;
-    accountVToken.userBorrowBalanceWei = borrowedAmountWei;
+    accountVToken.accountSupplyBalanceWei = suppliedAmountWei;
+    accountVToken.accountBorrowBalanceWei = borrowedAmountWei;
 
     accountVToken.totalUnderlyingRedeemedWei = zeroBigDecimal;
     accountVToken.accountBorrowIndex = zeroBigDecimal;

--- a/subgraphs/isolated-pools/src/operations/update.ts
+++ b/subgraphs/isolated-pools/src/operations/update.ts
@@ -62,7 +62,7 @@ export const updateAccountVTokenBorrow = (
     blockNumber,
     logIndex,
   );
-  accountVToken.userBorrowBalanceWei = accountBorrows;
+  accountVToken.accountBorrowBalanceWei = accountBorrows;
   accountVToken.accountBorrowIndex = borrowIndex;
   accountVToken.save();
   return accountVToken as AccountVToken;
@@ -89,7 +89,7 @@ export const updateAccountVTokenRepayBorrow = (
     blockNumber,
     logIndex,
   );
-  accountVToken.userBorrowBalanceWei = accountBorrows;
+  accountVToken.accountBorrowBalanceWei = accountBorrows;
   accountVToken.accountBorrowIndex = borrowIndex;
   accountVToken.save();
   return accountVToken as AccountVToken;
@@ -120,7 +120,7 @@ export const updateAccountVTokenTransferFrom = (
     blockNumber,
     logIndex,
   );
-  accountVToken.userSupplyBalanceWei = accountVToken.userSupplyBalanceWei.minus(amount);
+  accountVToken.accountSupplyBalanceWei = accountVToken.accountSupplyBalanceWei.minus(amount);
 
   accountVToken.totalUnderlyingRedeemedWei =
     accountVToken.totalUnderlyingRedeemedWei.plus(amountUnderlying);
@@ -148,7 +148,7 @@ export const updateAccountVTokenTransferTo = (
     logIndex,
   );
 
-  accountVToken.userSupplyBalanceWei = accountVToken.userSupplyBalanceWei.plus(amount);
+  accountVToken.accountSupplyBalanceWei = accountVToken.accountSupplyBalanceWei.plus(amount);
 
   accountVToken.save();
   return accountVToken as AccountVToken;

--- a/subgraphs/isolated-pools/tests/VToken/index.test.ts
+++ b/subgraphs/isolated-pools/tests/VToken/index.test.ts
@@ -282,7 +282,7 @@ describe('VToken', () => {
     assert.fieldEquals(
       'AccountVToken',
       accountVTokenId,
-      'userBorrowBalanceWei',
+      'accountBorrowBalanceWei',
       accountBorrows.toString(),
     );
     assert.fieldEquals(
@@ -370,7 +370,7 @@ describe('VToken', () => {
     assert.fieldEquals(
       'AccountVToken',
       accountVTokenId,
-      'userBorrowBalanceWei',
+      'accountBorrowBalanceWei',
       accountBorrows.toString(),
     );
     assert.fieldEquals(
@@ -564,7 +564,7 @@ describe('VToken', () => {
     assert.fieldEquals(
       'AccountVToken',
       accountVTokenId,
-      'userSupplyBalanceWei',
+      'accountSupplyBalanceWei',
       expectedFinalBalanceWei.toString(),
     );
 
@@ -638,7 +638,7 @@ describe('VToken', () => {
     assert.fieldEquals(
       'AccountVToken',
       accountVTokenId,
-      'userSupplyBalanceWei',
+      'accountSupplyBalanceWei',
       expectedFinalBalanceWei.toString(),
     );
   });

--- a/subgraphs/isolated-pools/tests/integration/queries/accountFromMarket.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/accountFromMarket.graphql
@@ -11,8 +11,8 @@ query AccountFromMarket($marketId: ID!, $accountId: ID!){
         block
       }
       enteredMarket
-      userSupplyBalanceWei
-      userBorrowBalanceWei
+      accountSupplyBalanceWei
+      accountBorrowBalanceWei
       totalUnderlyingRedeemedWei
       accountBorrowIndex
       totalUnderlyingRepaidWei

--- a/subgraphs/isolated-pools/tests/integration/queries/accountVTokens.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/accountVTokens.graphql
@@ -18,8 +18,8 @@ query AccountVTokens  {
       block
     }
     enteredMarket
-    userSupplyBalanceWei
-    userBorrowBalanceWei
+    accountSupplyBalanceWei
+    accountBorrowBalanceWei
     totalUnderlyingRedeemedWei
     accountBorrowIndex
     totalUnderlyingRepaidWei


### PR DESCRIPTION
## Jira ticket(s)

VEN-1084

## Changes
- Renamed `userSupplyBalanceWei` to `accountSupplyBalanceWei`
- Renamed `userBorrowBalanceWei` to `accountBorrowBalanceWei`