### PR TITLE
[VEN-1086] Directly call supplyRatePerBlock

### DIFF
--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -104,7 +104,7 @@ type Market @entity {
     "Reserves stored in the contract"
     reservesWei: BigInt!
     "Supply rate per block"
-    supplyRate: BigDecimal!
+    supplyRateMantissa: BigInt!
     "VToken symbol"
     symbol: String!
     "Underlying token address"

--- a/subgraphs/isolated-pools/src/operations/create.ts
+++ b/subgraphs/isolated-pools/src/operations/create.ts
@@ -144,11 +144,7 @@ export function createMarket(
     .truncate(mantissaFactor);
 
   market.reservesWei = vTokenContract.totalReserves();
-  market.supplyRate = vTokenContract
-    .supplyRatePerBlock()
-    .toBigDecimal()
-    .div(defaultMantissaFactorBigDecimal)
-    .truncate(mantissaFactor);
+  market.supplyRateMantissa = vTokenContract.supplyRatePerBlock();
 
   market.accrualBlockNumber = vTokenContract.accrualBlockNumber().toI32();
 

--- a/subgraphs/isolated-pools/src/operations/update.ts
+++ b/subgraphs/isolated-pools/src/operations/update.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, BigInt, Bytes, log } from '@graphprotocol/graph-ts';
+import { Address, BigDecimal, BigInt, Bytes } from '@graphprotocol/graph-ts';
 
 import { PoolMetadataUpdatedNewMetadataStruct } from '../../generated/PoolRegistry/PoolRegistry';
 import { AccountVToken, Market } from '../../generated/schema';
@@ -8,7 +8,6 @@ import {
   defaultMantissaFactorBigDecimal,
   mantissaFactor,
   vTokenDecimalsBigDecimal,
-  zeroBigDecimal,
 } from '../constants';
 import { exponentToBigDecimal } from '../utilities';
 import { getTokenPriceInUsd } from '../utilities';
@@ -216,18 +215,7 @@ export const updateMarket = (
     .div(defaultMantissaFactorBigDecimal)
     .truncate(mantissaFactor);
 
-  // This fails on only the first call to cZRX. It is unclear why, but otherwise it works.
-  // So we handle it like this.
-  const supplyRatePerBlock = marketContract.try_supplyRatePerBlock();
-  if (supplyRatePerBlock.reverted) {
-    log.info('***CALL FAILED*** : vBEP20 supplyRatePerBlock() reverted', []);
-    market.supplyRate = zeroBigDecimal;
-  } else {
-    market.supplyRate = supplyRatePerBlock.value
-      .toBigDecimal()
-      .div(defaultMantissaFactorBigDecimal)
-      .truncate(mantissaFactor);
-  }
+  market.supplyRateMantissa = marketContract.supplyRatePerBlock();
 
   market.treasuryTotalBorrowsWei = marketContract.totalBorrows();
   market.treasuryTotalSupplyWei = marketContract.totalSupply();

--- a/subgraphs/isolated-pools/tests/VToken/index.test.ts
+++ b/subgraphs/isolated-pools/tests/VToken/index.test.ts
@@ -480,7 +480,7 @@ describe('VToken', () => {
     assertMarketDocument('treasuryTotalBorrowsWei', '2641234234636158123');
     assertMarketDocument('cash', '1.418171344423412457');
     assertMarketDocument('borrowRate', '0.000000000012678493');
-    assertMarketDocument('supplyRate', '0.000000000012678493');
+    assertMarketDocument('supplyRateMantissa', '12678493');
   });
 
   test('registers new reserve factor', () => {

--- a/subgraphs/isolated-pools/tests/integration/pool.ts
+++ b/subgraphs/isolated-pools/tests/integration/pool.ts
@@ -132,7 +132,7 @@ describe('Pools', function () {
       expect(m.interestRateModelAddress).to.equal(interestRateModelAddresses[idx]);
       expect(m.name).to.equal(marketNames[idx]);
       expect(m.reservesWei).to.equal('0');
-      expect(m.supplyRate).to.equal('0');
+      expect(m.supplyRateMantissa).to.equal('0');
       expect(m.symbol).to.equal(symbols[idx]);
       expect(m.underlyingAddress).to.equal(underlyingAddresses[idx]);
       expect(m.underlyingName).to.equal(underlyingNames[idx]);

--- a/subgraphs/isolated-pools/tests/integration/queries/marketByIdQuery.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/marketByIdQuery.graphql
@@ -12,7 +12,7 @@ query MarketById($id: ID!) {
     interestRateModelAddress
     name
     reservesWei
-    supplyRate
+    supplyRateMantissa
     symbol
     underlyingAddress
     underlyingName


### PR DESCRIPTION
## Jira ticket(s)

VEN-1086

## Changes
- `supplyRatePerBlock` is now accessed directly