### PR TITLE
fix: fixed GraphQL documents based on new schema

### DIFF
--- a/subgraphs/isolated-pools/tests/integration/queries/marketByIdQuery.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/marketByIdQuery.graphql
@@ -5,10 +5,10 @@ query MarketById($id: ID!) {
       id
     }
     badDebtMantissa
-    borrowRate
+    borrowRateMantissa
     cash
-    collateralFactor
-    exchangeRate
+    collateralFactorMantissa
+    exchangeRateMantissa
     interestRateModelAddress
     name
     reservesMantissa
@@ -16,14 +16,14 @@ query MarketById($id: ID!) {
     symbol
     underlyingAddress
     underlyingName
-    underlyingPrice
+    underlyingPriceUsd
     underlyingSymbol
     borrowCapMantissa
     supplyCapMantissa
     accrualBlockNumber
     blockTimestamp
-    borrowIndex
-    reserveFactor
+    borrowIndexMantissa
+    reserveFactorMantissa
     underlyingPriceUsd
     underlyingDecimals
     supplierCount

--- a/subgraphs/isolated-pools/tests/integration/queries/marketsQuery.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/marketsQuery.graphql
@@ -5,24 +5,23 @@ query Markets {
       id
     }
     badDebtMantissa
-    borrowRate
+    borrowRateMantissa
     cash
-    collateralFactor
-    exchangeRate
+    collateralFactorMantissa
+    exchangeRateMantissa
     interestRateModelAddress
     name
     reservesMantissa
-    supplyRate
+    supplyRateMantissa
     symbol
     underlyingAddress
     underlyingName
-    underlyingPrice
     underlyingSymbol
     borrowCapMantissa
     accrualBlockNumber
     blockTimestamp
-    borrowIndex
-    reserveFactor
+    borrowIndexMantissa
+    reserveFactorMantissa
     underlyingPriceUsd
     underlyingDecimals
     supplyCapMantissa

--- a/subgraphs/isolated-pools/tests/integration/queries/poolsQuery.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/poolsQuery.graphql
@@ -9,9 +9,9 @@ query Pools {
     category
     logoUrl
     description
-    priceOracle
-    closeFactor
-    liquidationIncentive
+    priceOracleAddress
+    closeFactorMantissa
+    liquidationIncentiveMantissa
     minLiquidatableCollateralMantissa
     maxAssets
     markets {


### PR DESCRIPTION
## Changes
- GraphQL queries used during integration tests were outdated. This became evident now after hardhat deployment was sorted out.