### PR TITLE
feat: subgraph now works with isolated pools 0.0.18-develop.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/mustache": "^4.2.1",
     "@typescript-eslint/eslint-plugin": "^5.40.1",
     "@typescript-eslint/parser": "^5.40.1",
-    "@venusprotocol/isolated-pools": "^0.0.18-develop.1",
+    "@venusprotocol/isolated-pools": "^0.0.18-develop.2",
     "@venusprotocol/oracle": "^1.4.1",
     "@venusprotocol/venus-protocol": "^0.6.0",
     "assemblyscript": "0.19.23",

--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -58,8 +58,6 @@ type Pool @entity {
     liquidationIncentiveMantissa: BigInt!
     "Min Liquidable Amount allowed"
     minLiquidatableCollateralMantissa: BigInt!
-    "Max assets a single user can enter"
-    maxAssets: BigInt!
     "Markets associated to this pool"
     markets: [Market!]! @derivedFrom(field: "pool")
 

--- a/subgraphs/isolated-pools/src/operations/create.ts
+++ b/subgraphs/isolated-pools/src/operations/create.ts
@@ -81,7 +81,6 @@ export function createPool(comptroller: Address): Pool {
     pool.liquidationIncentiveMantissa = poolDataFromLens.liquidationIncentive
       ? poolDataFromLens.liquidationIncentive
       : new BigInt(0);
-    pool.maxAssets = poolDataFromLens.maxAssets ? poolDataFromLens.maxAssets : new BigInt(0);
     // Note: we don't index vTokens here because when a pool is created it has no markets
     pool.save();
   }

--- a/subgraphs/isolated-pools/template.yaml
+++ b/subgraphs/isolated-pools/template.yaml
@@ -31,7 +31,7 @@ dataSources:
         - name: BEP20
           file: ../../packages/isolated-pools-abis/Bep20.json
         - name: PoolLens
-          file: ../../packages/isolated-pools-abis/PoolLens.json
+          file: ../../node_modules/@venusprotocol/isolated-pools/artifacts/contracts/Lens/PoolLens.sol/PoolLens.json
         - name: RewardsDistributor
           file: ../../node_modules/@venusprotocol/isolated-pools/artifacts/contracts/Rewards/RewardsDistributor.sol/RewardsDistributor.json
       eventHandlers:
@@ -70,7 +70,7 @@ templates:
         - name: BEP20
           file: ../../packages/isolated-pools-abis/Bep20.json
         - name: PoolLens
-          file: ../../packages/isolated-pools-abis/PoolLens.json
+          file: ../../node_modules/@venusprotocol/isolated-pools/artifacts/contracts/Lens/PoolLens.sol/PoolLens.json
         - name: PriceOracle
           file: ../../node_modules/@venusprotocol/oracle/artifacts/contracts/PriceOracle.sol/PriceOracle.json
       eventHandlers:

--- a/subgraphs/isolated-pools/template.yaml
+++ b/subgraphs/isolated-pools/template.yaml
@@ -73,6 +73,8 @@ templates:
           file: ../../node_modules/@venusprotocol/isolated-pools/artifacts/contracts/Lens/PoolLens.sol/PoolLens.json
         - name: PriceOracle
           file: ../../node_modules/@venusprotocol/oracle/artifacts/contracts/PriceOracle.sol/PriceOracle.json
+        - name: RewardsDistributor
+          file: ../../node_modules/@venusprotocol/isolated-pools/artifacts/contracts/Rewards/RewardsDistributor.sol/RewardsDistributor.json
       eventHandlers:
         - event: MarketEntered(address,address)
           handler: handleMarketEntered

--- a/subgraphs/isolated-pools/tests/PoolRegistry/index.test.ts
+++ b/subgraphs/isolated-pools/tests/PoolRegistry/index.test.ts
@@ -67,7 +67,6 @@ describe('Pool Registry', () => {
     assertPoolDocument('priceOracleAddress', mockPriceOracleAddress.toHex());
     assertPoolDocument('closeFactorMantissa', '5');
     assertPoolDocument('liquidationIncentiveMantissa', '7');
-    assertPoolDocument('maxAssets', '10');
   });
 
   test('updates pool name correctly', () => {

--- a/subgraphs/isolated-pools/tests/VToken/mocks.ts
+++ b/subgraphs/isolated-pools/tests/VToken/mocks.ts
@@ -43,7 +43,6 @@ export const createPoolRegistryMock = (pools: Array<Array<ethereum.Value>>): voi
       ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(5)), // closeFactor
       ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(7)), // liquidationIncentive
       ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(6)), // minLiquidatableCollateralMantissa
-      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(10)), // maxAssets
       ethereum.Value.fromArray([ethereum.Value.fromTuple(vTokenData)]), // vTokens
     ];
     const lensTuple = changetype<ethereum.Tuple>(lensTupleArray);
@@ -52,7 +51,7 @@ export const createPoolRegistryMock = (pools: Array<Array<ethereum.Value>>): voi
     createMockedFunction(
       poolLensAddress,
       'getPoolByComptroller',
-      'getPoolByComptroller(address,address):((string,address,address,uint256,uint256,uint8,string,string,string,address,uint256,uint256,uint256,uint256,(address,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,bool,uint256,address,uint256,uint256)[]))',
+      'getPoolByComptroller(address,address):((string,address,address,uint256,uint256,uint8,string,string,string,address,uint256,uint256,uint256,(address,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,bool,uint256,address,uint256,uint256)[]))',
     )
       .withArgs([ethereum.Value.fromAddress(poolRegistryAddress), pool[2]])
       .returns([lensTupleValue]);

--- a/subgraphs/isolated-pools/tests/integration/poolRegistry.ts
+++ b/subgraphs/isolated-pools/tests/integration/poolRegistry.ts
@@ -15,7 +15,6 @@ const DEFAULT_POOL = {
   priceOracle: '0x0165878a594ca255338adfa4d48449f69242eb8f',
   closeFactor: '10000000000000000',
   liquidationIncentive: '2000000000000000000',
-  maxAssets: '0',
 };
 
 describe('Pool Registry', function () {
@@ -64,7 +63,6 @@ describe('Pool Registry', function () {
     expect(pool.priceOracleAddress).to.be.equal('0x0165878a594ca255338adfa4d48449f69242eb8f');
     expect(pool.closeFactor).to.be.equal('10000000000000000');
     expect(pool.liquidationIncentive).to.be.equal('2000000000000000000');
-    expect(pool.maxAssets).to.be.equal('0');
   });
 
   it('updates and returns metadata from the pool', async function () {

--- a/subgraphs/isolated-pools/tests/integration/queries/poolsQuery.graphql
+++ b/subgraphs/isolated-pools/tests/integration/queries/poolsQuery.graphql
@@ -13,7 +13,6 @@ query Pools {
     closeFactorMantissa
     liquidationIncentiveMantissa
     minLiquidatableCollateralMantissa
-    maxAssets
     markets {
       id
       pool {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4281,9 +4281,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@venusprotocol/isolated-pools@npm:^0.0.18-develop.1":
-  version: 0.0.18-develop.1
-  resolution: "@venusprotocol/isolated-pools@npm:0.0.18-develop.1"
+"@venusprotocol/isolated-pools@npm:^0.0.18-develop.2":
+  version: 0.0.18-develop.2
+  resolution: "@venusprotocol/isolated-pools@npm:0.0.18-develop.2"
   dependencies:
     "@openzeppelin/contracts": ^4.8.0
     "@openzeppelin/contracts-upgradeable": ^4.8.0
@@ -4291,7 +4291,7 @@ __metadata:
     "@solidity-parser/parser": ^0.13.2
     ethers: ^5.7.0
     hardhat-deploy: ^0.11.14
-  checksum: 14e5d25538f56539a3927d63d8f931c4ffd62aed89c98df6f7bd18763359db85525cac716db04c3821ab68ad0b40795db2c83e1179c929d3094ebf4e4651e176
+  checksum: 4df671ee793568d6d387c45b9f4f04d53a0defcd9cfc5dca3590627ac99c94d45b13f57612c5cda7723aaeef4f865614e613d3b98f78e8255a1ce79f7427d20c
   languageName: node
   linkType: hard
 
@@ -14778,7 +14778,7 @@ __metadata:
     "@types/mustache": ^4.2.1
     "@typescript-eslint/eslint-plugin": ^5.40.1
     "@typescript-eslint/parser": ^5.40.1
-    "@venusprotocol/isolated-pools": ^0.0.18-develop.1
+    "@venusprotocol/isolated-pools": ^0.0.18-develop.2
     "@venusprotocol/oracle": ^1.4.1
     "@venusprotocol/venus-protocol": ^0.6.0
     assemblyscript: 0.19.23


### PR DESCRIPTION
## Changes

- Bumped isolated-pools package to 0.0.18-develop.2
- Fixed the `RewardsDistributor` ABI reference missing from `Pool`
- Removing `maxAssets` from the subgraph, since got removed from `PoolLens`