### PR TITLE
[VEN-1170] Reward speeds get indexed when NewRewardsDistributor gets handled

### DIFF
--- a/subgraphs/isolated-pools/src/mappings/pool.ts
+++ b/subgraphs/isolated-pools/src/mappings/pool.ts
@@ -13,12 +13,12 @@ import {
   NewSupplyCap,
 } from '../../generated/PoolRegistry/Comptroller';
 import { RewardsDistributor as RewardsDistributorDataSource } from '../../generated/templates';
-import { createRewardDistributor } from '../operations/create';
 import {
   getOrCreateAccount,
   getOrCreateAccountVTokenTransaction,
   getOrCreateMarket,
   getOrCreatePool,
+  getOrCreateRewardDistributor,
 } from '../operations/getOrCreate';
 import {
   updateOrCreateAccountVToken,
@@ -155,5 +155,5 @@ export function handleNewSupplyCap(event: NewSupplyCap): void {
 
 export function handleNewRewardsDistributor(event: NewRewardsDistributor): void {
   RewardsDistributorDataSource.create(event.params.rewardsDistributor);
-  createRewardDistributor(event.params.rewardsDistributor, event.address);
+  getOrCreateRewardDistributor(event.params.rewardsDistributor, event.address);
 }

--- a/subgraphs/isolated-pools/tests/Pool/index.test.ts
+++ b/subgraphs/isolated-pools/tests/Pool/index.test.ts
@@ -103,6 +103,10 @@ beforeAll(() => {
     ],
   ]);
 
+  createMockedFunction(comptrollerAddress, 'getAllMarkets', 'getAllMarkets():(address[])').returns([
+    ethereum.Value.fromArray([]),
+  ]);
+
   createRewardsDistributorMock(rewardsDistributorAddress, tokenAddress);
 });
 

--- a/subgraphs/isolated-pools/tests/RewardsDistributor/index.test.ts
+++ b/subgraphs/isolated-pools/tests/RewardsDistributor/index.test.ts
@@ -1,7 +1,9 @@
-import { Address, BigInt } from '@graphprotocol/graph-ts';
+import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts';
+import { createMockedFunction } from 'matchstick-as';
 import {
   afterEach,
   assert,
+  beforeAll,
   beforeEach,
   clearStore,
   describe,
@@ -30,6 +32,12 @@ const tokenAddress = Address.fromString('0x0000000000000000000000000000000000000
 const cleanup = (): void => {
   clearStore();
 };
+
+beforeAll(() => {
+  createMockedFunction(comptrollerAddress, 'getAllMarkets', 'getAllMarkets():(address[])').returns([
+    ethereum.Value.fromArray([]),
+  ]);
+});
 
 beforeEach(() => {
   createRewardsDistributorMock(rewardsDistributorAddress, tokenAddress);


### PR DESCRIPTION
## Changes
- We are now reading reward speeds for each market from the corresponding rewards distributor whenever we receive a `NewRewardsDistributor` event. This way we won't have empty values for reward speeds until `RewardTokenBorrowSpeedUpdated` and `RewardTokenSupplySpeedUpdated` are handled.