### PR TITLE
[VEN-1179] getUnderlyingPrice now fallbacks if reverted

### DIFF
--- a/subgraphs/isolated-pools/src/utilities/getTokenPriceInUsd.ts
+++ b/subgraphs/isolated-pools/src/utilities/getTokenPriceInUsd.ts
@@ -22,10 +22,12 @@ const getTokenPrice = (
      */
     const mantissaDecimalFactor = exponentToBigDecimal(36 - underlyingDecimals);
     const priceOracle = PriceOracle.bind(oracleAddress);
-    underlyingPrice = priceOracle
-      .getUnderlyingPrice(eventAddress)
-      .toBigDecimal()
-      .div(mantissaDecimalFactor);
+    // Calling getUnderlyingPrice might revert if the pyth price pusher is unfunded
+    // On revert we will return 0
+    const underlyingPriceResult = priceOracle.try_getUnderlyingPrice(eventAddress);
+    if (!underlyingPriceResult.reverted) {
+      underlyingPrice = underlyingPriceResult.value.toBigDecimal().div(mantissaDecimalFactor);
+    }
   }
 
   return underlyingPrice;


### PR DESCRIPTION
## Changes

Calling `getUnderlyingPrice` can revert due to an invalid price, such as when the pyth price pusher is not working. This means that trying to read underlying prices for a market in a block where it reverts would make the subgraph stop working. This PR changes it so that we first check if the call was reverted.

- If it didn't revert, use the price returned
- If it did revert, fallback to 0