### PR TITLE
refactor: query vToken decimal instead of assuming it is 18

### DIFF
--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -133,6 +133,8 @@ type Market @entity {
     underlyingPriceUsd: BigDecimal!
     "Underlying token decimal length"
     underlyingDecimals: Int!
+    "vToken decimal length"
+    vTokenDecimals: Int!
 
     "Supply cap set for market"
     supplyCapMantissa: BigInt!

--- a/subgraphs/isolated-pools/src/constants/index.ts
+++ b/subgraphs/isolated-pools/src/constants/index.ts
@@ -9,9 +9,6 @@ export const oneBigInt = BigInt.fromString('1');
 export const mantissaFactor = 18;
 export const defaultMantissaFactorBigDecimal: BigDecimal = exponentToBigDecimal(mantissaFactor);
 
-export const vTokenDecimals = 8;
-export const vTokenDecimalsBigDecimal: BigDecimal = exponentToBigDecimal(vTokenDecimals);
-
 export const BORROW = 'BORROW';
 export const MINT = 'MINT';
 export const REDEEM = 'REDEEM';

--- a/subgraphs/isolated-pools/src/mappings/vToken.ts
+++ b/subgraphs/isolated-pools/src/mappings/vToken.ts
@@ -49,7 +49,7 @@ import {
 export function handleMint(event: Mint): void {
   const vTokenAddress = event.address;
   const market = getOrCreateMarket(vTokenAddress, null);
-  createMintTransaction(event, market.underlyingDecimals);
+  createMintTransaction(event, market.underlyingDecimals, market.vTokenDecimals);
 
   // we read the current total amount of supplied tokens by this account in the market
   const suppliedTotal = event.params.accountBalance;
@@ -75,7 +75,7 @@ export function handleMint(event: Mint): void {
 export function handleRedeem(event: Redeem): void {
   const vTokenAddress = event.address;
   const market = getOrCreateMarket(vTokenAddress);
-  createRedeemTransaction(event, market.underlyingDecimals);
+  createRedeemTransaction(event, market.underlyingDecimals, market.vTokenDecimals);
 
   // we read the account's balance and...
   const currentBalance = event.params.accountBalance;
@@ -185,7 +185,7 @@ export function handleLiquidateBorrow(event: LiquidateBorrow): void {
   borrower.countLiquidated = borrower.countLiquidated + 1;
   borrower.save();
 
-  createLiquidateBorrowTransaction(event, market.underlyingDecimals);
+  createLiquidateBorrowTransaction(event, market.underlyingDecimals, market.vTokenDecimals);
 }
 
 export function handleAccrueInterest(event: AccrueInterest): void {
@@ -242,6 +242,7 @@ export function handleTransfer(event: Transfer): void {
       event.params.amount,
       market.exchangeRateMantissa,
       market.underlyingDecimals,
+      market.vTokenDecimals,
     );
   }
 
@@ -264,7 +265,7 @@ export function handleTransfer(event: Transfer): void {
     );
   }
 
-  createTransferTransaction(event);
+  createTransferTransaction(event, market.vTokenDecimals);
 }
 
 export function handleNewMarketInterestRateModel(event: NewMarketInterestRateModel): void {

--- a/subgraphs/isolated-pools/src/operations/create.ts
+++ b/subgraphs/isolated-pools/src/operations/create.ts
@@ -34,8 +34,6 @@ import {
   TRANSFER,
   UNDERLYING_AMOUNT,
   UNDERLYING_REPAY_AMOUNT,
-  vTokenDecimals,
-  vTokenDecimalsBigDecimal,
   zeroBigInt32,
 } from '../constants';
 import { poolLensAddress, poolRegistryAddress } from '../constants/addresses';
@@ -121,6 +119,7 @@ export function createMarket(
   market.underlyingSymbol = underlyingContract.symbol();
   market.underlyingPriceUsd = underlyingValue;
   market.underlyingDecimals = underlyingDecimals;
+  market.vTokenDecimals = vTokenContract.decimals();
 
   market.borrowRateMantissa = vTokenContract.borrowRatePerBlock();
 
@@ -166,7 +165,11 @@ export function createMarket(
   return market;
 }
 
-export const createMintTransaction = (event: Mint, underlyingDecimals: i32): void => {
+export const createMintTransaction = (
+  event: Mint,
+  underlyingDecimals: i32,
+  vTokenDecimals: i32,
+): void => {
   const id = getTransactionEventId(event.transaction.hash, event.transactionLogIndex);
   const underlyingAmount = event.params.mintAmount
     .toBigDecimal()
@@ -175,7 +178,7 @@ export const createMintTransaction = (event: Mint, underlyingDecimals: i32): voi
 
   const vTokenAmount = event.params.mintTokens
     .toBigDecimal()
-    .div(vTokenDecimalsBigDecimal)
+    .div(exponentToBigDecimal(vTokenDecimals))
     .truncate(vTokenDecimals);
 
   const transaction = new Transaction(id);
@@ -195,7 +198,11 @@ export const createMintTransaction = (event: Mint, underlyingDecimals: i32): voi
   transaction.save();
 };
 
-export const createRedeemTransaction = (event: Redeem, underlyingDecimals: i32): void => {
+export const createRedeemTransaction = (
+  event: Redeem,
+  underlyingDecimals: i32,
+  vTokenDecimals: i32,
+): void => {
   const id = getTransactionEventId(event.transaction.hash, event.transactionLogIndex);
   const underlyingAmount = event.params.redeemAmount
     .toBigDecimal()
@@ -204,7 +211,7 @@ export const createRedeemTransaction = (event: Redeem, underlyingDecimals: i32):
 
   const vTokenAmount = event.params.redeemTokens
     .toBigDecimal()
-    .div(vTokenDecimalsBigDecimal)
+    .div(exponentToBigDecimal(vTokenDecimals))
     .truncate(vTokenDecimals);
 
   const transaction = new Transaction(id);
@@ -286,6 +293,7 @@ export const createRepayBorrowTransaction = (event: RepayBorrow, underlyingDecim
 export const createLiquidateBorrowTransaction = (
   event: LiquidateBorrow,
   underlyingDecimals: i32,
+  vTokenDecimals: i32,
 ): void => {
   const id = getTransactionEventId(event.transaction.hash, event.transactionLogIndex);
   const amount = event.params.seizeTokens
@@ -315,7 +323,7 @@ export const createLiquidateBorrowTransaction = (
   transaction.save();
 };
 
-export const createTransferTransaction = (event: Transfer): void => {
+export const createTransferTransaction = (event: Transfer, vTokenDecimals: i32): void => {
   const id = getTransactionEventId(event.transaction.hash, event.transactionLogIndex);
   const amount = event.params.amount.toBigDecimal().div(exponentToBigDecimal(vTokenDecimals));
 

--- a/subgraphs/isolated-pools/src/operations/update.ts
+++ b/subgraphs/isolated-pools/src/operations/update.ts
@@ -105,8 +105,13 @@ export const updateAccountVTokenTransferFrom = (
   amount: BigInt,
   exchangeRate: BigInt,
   underlyingDecimals: i32,
+  vTokenDecimals: i32,
 ): AccountVToken => {
-  const exchangeRateBigDecimal = getExchangeRateBigDecimal(exchangeRate, underlyingDecimals);
+  const exchangeRateBigDecimal = getExchangeRateBigDecimal(
+    exchangeRate,
+    underlyingDecimals,
+    vTokenDecimals,
+  );
   const amountUnderlyingMantissa = exchangeRateBigDecimal
     .times(exponentToBigDecimal(underlyingDecimals))
     .times(amount.toBigDecimal());

--- a/subgraphs/isolated-pools/src/utilities/getExchangeRateBigDecimal.ts
+++ b/subgraphs/isolated-pools/src/utilities/getExchangeRateBigDecimal.ts
@@ -1,15 +1,12 @@
 import { BigDecimal, BigInt } from '@graphprotocol/graph-ts';
 
-import {
-  defaultMantissaFactorBigDecimal,
-  mantissaFactor,
-  vTokenDecimalsBigDecimal,
-} from '../constants/index';
+import { defaultMantissaFactorBigDecimal, mantissaFactor } from '../constants/index';
 import exponentToBigDecimal from '../utilities/exponentToBigDecimal';
 
 const getExchangeRateBigDecimal = (
   exchangeRateMantissa: BigInt,
   underlyingDecimals: i32,
+  vTokenDecimals: i32,
 ): BigDecimal => {
   /* Exchange rate explanation
     In Practice
@@ -24,7 +21,7 @@ const getExchangeRateBigDecimal = (
   const exchangeRate = exchangeRateMantissa
     .toBigDecimal()
     .div(exponentToBigDecimal(underlyingDecimals))
-    .times(vTokenDecimalsBigDecimal)
+    .times(exponentToBigDecimal(vTokenDecimals))
     .div(defaultMantissaFactorBigDecimal)
     .truncate(mantissaFactor);
 

--- a/subgraphs/isolated-pools/tests/VToken/index.test.ts
+++ b/subgraphs/isolated-pools/tests/VToken/index.test.ts
@@ -20,8 +20,6 @@ import {
   UNDERLYING_AMOUNT,
   UNDERLYING_REPAY_AMOUNT,
   oneBigInt,
-  vTokenDecimals,
-  vTokenDecimalsBigDecimal,
   zeroBigInt32,
 } from '../../src/constants';
 import { handleMarketAdded, handlePoolRegistered } from '../../src/mappings/poolRegistry';
@@ -154,7 +152,7 @@ describe('VToken', () => {
       'Transaction',
       id,
       'amount',
-      mintTokens.toBigDecimal().div(vTokenDecimalsBigDecimal).truncate(vTokenDecimals).toString(),
+      mintTokens.toBigDecimal().div(exponentToBigDecimal(18)).truncate(18).toString(),
     );
     assert.fieldEquals('Transaction', id, 'to', minter.toHexString());
     assert.fieldEquals('Transaction', id, 'blockNumber', mintEvent.block.number.toString());
@@ -199,7 +197,7 @@ describe('VToken', () => {
       'Transaction',
       id,
       'amount',
-      redeemTokens.toBigDecimal().div(vTokenDecimalsBigDecimal).truncate(vTokenDecimals).toString(),
+      redeemTokens.toBigDecimal().div(exponentToBigDecimal(18)).truncate(18).toString(),
     );
     assert.fieldEquals('Transaction', id, 'to', redeemer.toHexString());
     assert.fieldEquals('Transaction', id, 'blockNumber', redeemEvent.block.number.toString());
@@ -578,7 +576,7 @@ describe('VToken', () => {
       'AccountVToken',
       accountVTokenId,
       'totalUnderlyingRedeemedMantissa',
-      '5337167017820446167010750000',
+      '53371670178204461670107500000000000000',
     );
   });
 

--- a/subgraphs/isolated-pools/tests/VToken/mocks.ts
+++ b/subgraphs/isolated-pools/tests/VToken/mocks.ts
@@ -83,6 +83,10 @@ export const createVBep20AndUnderlyingMock = (
     ethereum.Value.fromString(`v${symbol}`),
   ]);
 
+  createMockedFunction(contractAddress, 'decimals', 'decimals():(uint8)').returns([
+    ethereum.Value.fromI32(18),
+  ]);
+
   createMockedFunction(
     contractAddress,
     'interestRateModel',


### PR DESCRIPTION
Refactors the Isolated Pools subgraph so that it doesn't assume the vToken decimal is 8 and instead queries the contract. The vToken decimal is 8 for the core pool but should be set as 18 for the isolated markets 