### PR TITLE
refactor: remove try from getPoolByComptroller

### DIFF
--- a/subgraphs/isolated-pools/src/operations/create.ts
+++ b/subgraphs/isolated-pools/src/operations/create.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, log } from '@graphprotocol/graph-ts';
+import { Address, BigInt } from '@graphprotocol/graph-ts';
 
 import { PoolLens as PoolLensContract } from '../../generated/PoolRegistry/PoolLens';
 import {
@@ -50,36 +50,26 @@ export function createPool(comptroller: Address): Pool {
   const pool = new Pool(getPoolId(comptroller));
   // Fill in pool from pool lens
   const poolLensContract = PoolLensContract.bind(poolLensAddress);
-  const getPoolByComptrollerResult = poolLensContract.try_getPoolByComptroller(
-    poolRegistryAddress,
-    comptroller,
-  );
+  const poolDataFromLens = poolLensContract.getPoolByComptroller(poolRegistryAddress, comptroller);
 
-  if (getPoolByComptrollerResult.reverted) {
-    log.error('Unable to fetch pool info for {} with lens {}', [
-      comptroller.toHexString(),
-      poolLensAddress.toHexString(),
-    ]);
-  } else {
-    const poolDataFromLens = getPoolByComptrollerResult.value;
-    pool.name = poolDataFromLens.name;
-    pool.creator = poolDataFromLens.creator;
-    pool.blockPosted = poolDataFromLens.blockPosted;
-    pool.timestampPosted = poolDataFromLens.timestampPosted;
-    pool.category = poolDataFromLens.category;
-    pool.logoUrl = poolDataFromLens.logoURL;
-    pool.description = poolDataFromLens.description;
-    pool.priceOracleAddress = poolDataFromLens.priceOracle;
-    pool.closeFactorMantissa = poolDataFromLens.closeFactor
-      ? poolDataFromLens.closeFactor
-      : new BigInt(0);
-    pool.minLiquidatableCollateralMantissa = poolDataFromLens.minLiquidatableCollateral;
-    pool.liquidationIncentiveMantissa = poolDataFromLens.liquidationIncentive
-      ? poolDataFromLens.liquidationIncentive
-      : new BigInt(0);
-    // Note: we don't index vTokens here because when a pool is created it has no markets
-    pool.save();
-  }
+  pool.name = poolDataFromLens.name;
+  pool.creator = poolDataFromLens.creator;
+  pool.blockPosted = poolDataFromLens.blockPosted;
+  pool.timestampPosted = poolDataFromLens.timestampPosted;
+  pool.category = poolDataFromLens.category;
+  pool.logoUrl = poolDataFromLens.logoURL;
+  pool.description = poolDataFromLens.description;
+  pool.priceOracleAddress = poolDataFromLens.priceOracle;
+  pool.closeFactorMantissa = poolDataFromLens.closeFactor
+    ? poolDataFromLens.closeFactor
+    : new BigInt(0);
+  pool.minLiquidatableCollateralMantissa = poolDataFromLens.minLiquidatableCollateral;
+  pool.liquidationIncentiveMantissa = poolDataFromLens.liquidationIncentive
+    ? poolDataFromLens.liquidationIncentive
+    : new BigInt(0);
+  // Note: we don't index vTokens here because when a pool is created it has no markets
+  pool.save();
+
   return pool;
 }
 


### PR DESCRIPTION
## Changes

- Refactored `try_getPoolByComptroller` to be `getPoolByComptroller`. No need to try it anymore since this call is not meant to silently error, previous version was meant to debug the subgraph failing to index it