### PR TITLE
fix double accounting issue when updating transfers from borrowi when updating transfers from borrowing activity

### DIFF
--- a/subgraphs/isolated-pools/src/mappings/vToken.ts
+++ b/subgraphs/isolated-pools/src/mappings/vToken.ts
@@ -261,7 +261,6 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.block.number,
       event.logIndex,
-      event.params.amount,
     );
   }
 

--- a/subgraphs/isolated-pools/src/operations/update.ts
+++ b/subgraphs/isolated-pools/src/operations/update.ts
@@ -125,8 +125,6 @@ export const updateAccountVTokenTransferFrom = (
     blockNumber,
     logIndex,
   );
-  accountVToken.accountSupplyBalanceMantissa =
-    accountVToken.accountSupplyBalanceMantissa.minus(amount);
 
   accountVToken.totalUnderlyingRedeemedMantissa =
     accountVToken.totalUnderlyingRedeemedMantissa.plus(amountUnderlyingMantissa);
@@ -142,7 +140,6 @@ export const updateAccountVTokenTransferTo = (
   timestamp: BigInt,
   blockNumber: BigInt,
   logIndex: BigInt,
-  amount: BigInt,
 ): AccountVToken => {
   const accountVToken = updateAccountVToken(
     marketAddress,
@@ -153,9 +150,6 @@ export const updateAccountVTokenTransferTo = (
     blockNumber,
     logIndex,
   );
-
-  accountVToken.accountSupplyBalanceMantissa =
-    accountVToken.accountSupplyBalanceMantissa.plus(amount);
 
   accountVToken.save();
   return accountVToken as AccountVToken;

--- a/subgraphs/isolated-pools/tests/VToken/index.test.ts
+++ b/subgraphs/isolated-pools/tests/VToken/index.test.ts
@@ -512,7 +512,6 @@ describe('VToken', () => {
     const to = aaaTokenAddress;
     const amount = BigInt.fromString('146205398726345');
     const balanceOf = BigInt.fromString('262059874253345');
-    const expectedFinalBalanceMantissa = balanceOf.minus(amount);
 
     /** Setup test */
     const transferEvent = createTransferEvent(aaaTokenAddress, from, to, amount);
@@ -568,13 +567,6 @@ describe('VToken', () => {
     assert.fieldEquals(
       'AccountVToken',
       accountVTokenId,
-      'accountSupplyBalanceMantissa',
-      expectedFinalBalanceMantissa.toString(),
-    );
-
-    assert.fieldEquals(
-      'AccountVToken',
-      accountVTokenId,
       'totalUnderlyingRedeemedMantissa',
       '53371670178204461670107500000000000000',
     );
@@ -586,7 +578,6 @@ describe('VToken', () => {
     const from = aaaTokenAddress;
     const to = user2Address;
     const balanceOf = BigInt.fromString('262059874253345');
-    const expectedFinalBalanceMantissa = balanceOf.plus(amount);
 
     /** Setup test */
     const transferEvent = createTransferEvent(aaaTokenAddress, from, to, amount);
@@ -638,13 +629,6 @@ describe('VToken', () => {
     );
 
     assert.fieldEquals('AccountVToken', accountVTokenId, 'accountBorrowIndexMantissa', '0');
-
-    assert.fieldEquals(
-      'AccountVToken',
-      accountVTokenId,
-      'accountSupplyBalanceMantissa',
-      expectedFinalBalanceMantissa.toString(),
-    );
   });
 
   test('registers new interest rate model', () => {


### PR DESCRIPTION
Balances are updated directly when processing related events