### PR TITLE
refactor: save supply in underlying token mantissa

### DIFF
--- a/subgraphs/isolated-pools/schema.graphql
+++ b/subgraphs/isolated-pools/schema.graphql
@@ -101,9 +101,9 @@ type Market @entity {
     underlyingSymbol: String!
     "Max token borrow amount allowed"
     borrowCapMantissa: BigInt!
-    "Total borrowed"
+    "Total borrowed underlying token"
     totalBorrowsMantissa: BigInt!
-    "Total supplied"
+    "Total supplied underlying token"
     totalSupplyMantissa: BigInt!
 
     # Fields that are not in Venus api

--- a/subgraphs/isolated-pools/src/operations/create.ts
+++ b/subgraphs/isolated-pools/src/operations/create.ts
@@ -38,6 +38,7 @@ import {
 import { poolLensAddress, poolRegistryAddress } from '../constants/addresses';
 import { getTokenPriceInCents } from '../utilities';
 import exponentToBigDecimal from '../utilities/exponentToBigDecimal';
+import exponentToBigInt from '../utilities/exponentToBigInt';
 import {
   getAccountVTokenId,
   getBadDebtEventId,
@@ -111,8 +112,8 @@ export function createMarket(
   market.borrowRateMantissa = vTokenContract.borrowRatePerBlock();
 
   market.cashMantissa = vTokenContract.getCash();
-
-  market.exchangeRateMantissa = vTokenContract.exchangeRateStored();
+  const exchangeRateMantissa = vTokenContract.exchangeRateStored();
+  market.exchangeRateMantissa = exchangeRateMantissa;
 
   market.reservesMantissa = vTokenContract.totalReserves();
   market.supplyRateMantissa = vTokenContract.supplyRatePerBlock();
@@ -126,7 +127,11 @@ export function createMarket(
   market.reserveFactorMantissa = vTokenContract.reserveFactorMantissa();
 
   market.totalBorrowsMantissa = vTokenContract.totalBorrows();
-  market.totalSupplyMantissa = vTokenContract.totalSupply();
+
+  const totalSupplyVTokensMantissa = vTokenContract.totalSupply();
+  market.totalSupplyMantissa = totalSupplyVTokensMantissa
+    .times(exchangeRateMantissa)
+    .div(exponentToBigInt(18));
 
   market.badDebtMantissa = vTokenContract.badDebt();
 

--- a/subgraphs/isolated-pools/tests/VToken/index.test.ts
+++ b/subgraphs/isolated-pools/tests/VToken/index.test.ts
@@ -570,7 +570,7 @@ describe('VToken', () => {
 
     assertMarketDocument('accrualBlockNumber', '999');
     assertMarketDocument('blockTimestamp', accrueInterestEvent.block.timestamp.toString());
-    assertMarketDocument('totalSupplyMantissa', '36504567163409');
+    assertMarketDocument('totalSupplyMantissa', '13325839781677697472');
     assertMarketDocument('exchangeRateMantissa', '365045823500000000000000');
     assertMarketDocument('borrowIndexMantissa', '300000000000000000000');
     assertMarketDocument('reservesMantissa', '5128924555022289393');

--- a/subgraphs/venus/schema.graphql
+++ b/subgraphs/venus/schema.graphql
@@ -41,7 +41,7 @@ type Market @entity {
     id: ID!
     "Borrows in the market"
     totalBorrowsMantissa: BigInt!
-    "VToken supply. VTokens have 8 decimals"
+    "Total underlying supplied"
     totalSupplyMantissa: BigInt!
     "Underlying token address"
     underlyingAddress: Bytes!


### PR DESCRIPTION
Convert underlying supply from vTokens to underlying so that both borrow and supply values are in underlying tokens