### PR TITLE
feat: listen to updated vToken events

### DIFF
--- a/subgraphs/venus/src/mappings/comptroller.ts
+++ b/subgraphs/venus/src/mappings/comptroller.ts
@@ -13,7 +13,7 @@ import {
   NewPriceOracle,
 } from '../../generated/Comptroller/Comptroller';
 import { Account, Market } from '../../generated/schema';
-import { VToken } from '../../generated/templates';
+import { VToken, VTokenUpdatedEvents } from '../../generated/templates';
 import { createAccount, createMarket } from '../operations/create';
 import { getOrCreateComptroller } from '../operations/getOrCreate';
 import { updateCommonVTokenStats } from '../operations/update';
@@ -22,6 +22,7 @@ import { ensureComptrollerSynced } from '../utilities';
 export function handleMarketListed(event: MarketListed): void {
   // Dynamically index all new listed tokens
   VToken.create(event.params.vToken);
+  VTokenUpdatedEvents.create(event.params.vToken);
   // Create the market for this token, since it's now been listed.
   createMarket(event.params.vToken.toHexString());
 }


### PR DESCRIPTION
We need to add listening to both the original and updated events when we add a market