### PR TITLE
fix: handle possible exchange rate math failure

### DIFF
--- a/subgraphs/venus/src/operations/update.ts
+++ b/subgraphs/venus/src/operations/update.ts
@@ -4,6 +4,7 @@ import { AccountVToken, Market } from '../../generated/schema';
 import { VToken } from '../../generated/templates/VToken/VToken';
 import { zeroBigInt32 } from '../constants';
 import { createMarket } from '../operations/create';
+import { getExchangeRate } from '../utilities';
 import { exponentToBigInt } from '../utilities/exponentToBigInt';
 import { getUnderlyingPrice } from '../utilities/getUnderlyingPrice';
 import { createAccountVToken } from './create';
@@ -41,8 +42,8 @@ export const updateMarket = (
 
   // Only updateMarket if it has not been updated this block
   if (market.accrualBlockNumber != blockNumber) {
-    const contractAddress = Address.fromString(market.id);
-    const contract = VToken.bind(contractAddress);
+    const marketAddress = Address.fromString(market.id);
+    const contract = VToken.bind(marketAddress);
     market.accrualBlockNumber = contract.accrualBlockNumber().toI32();
     market.blockTimestamp = blockTimestamp;
 
@@ -59,7 +60,7 @@ export const updateMarket = (
         - Must multiply by vtokenDecimals, 10^8
         - Must div by mantissa, 10^18
      */
-    const exchangeRateStored = contract.exchangeRateStored();
+    const exchangeRateStored = getExchangeRate(marketAddress);
     market.exchangeRateMantissa = exchangeRateStored;
 
     const totalSupplyVTokensMantissa = contract.totalSupply();

--- a/subgraphs/venus/src/utilities/getExchangeRate.ts
+++ b/subgraphs/venus/src/utilities/getExchangeRate.ts
@@ -1,0 +1,15 @@
+import { Address, BigInt, log } from '@graphprotocol/graph-ts';
+
+import { VToken } from '../../generated/templates/VToken/VToken';
+import valueOrNotAvailableIntIfReverted from './valueOrNotAvailableIntIfReverted';
+
+export function getExchangeRate(marketAddress: Address): BigInt {
+  const vTokenContract = VToken.bind(marketAddress);
+  const tryExchangeRateStored = vTokenContract.try_exchangeRateStored();
+  if (tryExchangeRateStored.reverted) {
+    log.warning('Failed to get exchange rate for {}', [marketAddress.toHexString()]);
+  }
+  return valueOrNotAvailableIntIfReverted(tryExchangeRateStored);
+}
+
+export default getExchangeRate;

--- a/subgraphs/venus/src/utilities/index.ts
+++ b/subgraphs/venus/src/utilities/index.ts
@@ -2,3 +2,5 @@ export { getTokenPriceCents } from './getTokenPriceCents';
 export { exponentToBigDecimal } from './exponentToBigDecimal';
 export { ensureComptrollerSynced } from './ensureComptrollerSynced';
 export { getUnderlyingPrice } from './getUnderlyingPrice';
+export { default as valueOrNotAvailableIntIfReverted } from './valueOrNotAvailableIntIfReverted';
+export { default as getExchangeRate } from './getExchangeRate';

--- a/subgraphs/venus/src/utilities/valueOrNotAvailableIntIfReverted.ts
+++ b/subgraphs/venus/src/utilities/valueOrNotAvailableIntIfReverted.ts
@@ -1,0 +1,10 @@
+import { BigInt, ethereum } from '@graphprotocol/graph-ts';
+
+import { NOT_AVAILABLE_BIG_INT } from '../constants';
+
+// checks if a call reverted, in case it is we return -1 to indicate the wanted value is not available
+function valueOrNotAvailableIntIfReverted(callResult: ethereum.CallResult<BigInt>): BigInt {
+  return callResult.reverted ? NOT_AVAILABLE_BIG_INT : callResult.value;
+}
+
+export default valueOrNotAvailableIntIfReverted;


### PR DESCRIPTION
Fetching the exchange rate can potentially fail due to math errors. This PR updates so we can gracefully handle and log those errors