### PR TITLE
refactor: for added safety always try to get exchange rate

### DIFF
--- a/subgraphs/isolated-pools/src/operations/create.ts
+++ b/subgraphs/isolated-pools/src/operations/create.ts
@@ -24,8 +24,11 @@ import { BEP20 as BEP20Contract } from '../../generated/templates/VToken/BEP20';
 import { VToken as VTokenContract } from '../../generated/templates/VToken/VToken';
 import { BORROW, LIQUIDATE, MINT, REDEEM, REPAY, TRANSFER, zeroBigInt32 } from '../constants';
 import { poolLensAddress, poolRegistryAddress } from '../constants/addresses';
-import { getTokenPriceInCents } from '../utilities';
-import exponentToBigInt from '../utilities/exponentToBigInt';
+import {
+  exponentToBigInt,
+  getTokenPriceInCents,
+  valueOrNotAvailableIntIfReverted,
+} from '../utilities';
 import {
   getAccountVTokenId,
   getBadDebtEventId,
@@ -99,7 +102,10 @@ export function createMarket(
   market.borrowRateMantissa = vTokenContract.borrowRatePerBlock();
 
   market.cashMantissa = vTokenContract.getCash();
-  const exchangeRateMantissa = vTokenContract.exchangeRateStored();
+  const exchangeRateMantissa = valueOrNotAvailableIntIfReverted(
+    vTokenContract.try_exchangeRateStored(),
+  );
+
   market.exchangeRateMantissa = exchangeRateMantissa;
 
   market.reservesMantissa = vTokenContract.totalReserves();


### PR DESCRIPTION
The exchange rate calls can fail due to a math error. Generally this won't happen on market creation but for added safety we can make all calls for getting the exchange rate in a try_