### PR TITLE
feat: cleanup Core Pool subgraph RPC calls

### DIFF
--- a/subgraphs/venus/src/operations/updateMarketBorrowRate.ts
+++ b/subgraphs/venus/src/operations/updateMarketBorrowRate.ts
@@ -1,0 +1,10 @@
+import { Market } from '../../generated/schema';
+import { VToken } from '../../generated/templates/VToken/VToken';
+import { valueOrNotAvailableIntIfReverted } from '../utilities';
+
+export function updateMarketBorrowRate(market: Market, vTokenContract: VToken): void {
+  market.borrowRateMantissa = valueOrNotAvailableIntIfReverted(
+    vTokenContract.try_borrowRatePerBlock(),
+    'vBEP20 try_borrowRatePerBlock()',
+  );
+}

--- a/subgraphs/venus/src/operations/updateMarketCashMantissa.ts
+++ b/subgraphs/venus/src/operations/updateMarketCashMantissa.ts
@@ -1,0 +1,6 @@
+import { Market } from '../../generated/schema';
+import { VToken } from '../../generated/templates/VToken/VToken';
+
+export function updateMarketCashMantissa(market: Market, vTokenContract: VToken): void {
+  market.cashMantissa = vTokenContract.getCash();
+}

--- a/subgraphs/venus/src/operations/updateMarketExchangeRate.ts
+++ b/subgraphs/venus/src/operations/updateMarketExchangeRate.ts
@@ -1,0 +1,20 @@
+import { Market } from '../../generated/schema';
+import { VToken } from '../../generated/templates/VToken/VToken';
+import { valueOrNotAvailableIntIfReverted } from '../utilities';
+
+/* Exchange rate explanation
+  In Practice
+  - If you call the vDAI contract on bscscan it comes back (2.0 * 10^26)
+  - If you call the vUSDC contract on bscscan it comes back (2.0 * 10^14)
+  - The real value is ~0.02. So vDAI is off by 10^28, and vUSDC 10^16
+  How to calculate for tokens with different decimals
+  - Must div by tokenDecimals, 10^market.underlyingDecimals
+  - Must multiply by vtokenDecimals, 10^8
+  - Must div by mantissa, 10^18
+*/
+export function updateMarketExchangeRate(market: Market, vTokenContract: VToken): void {
+  market.exchangeRateMantissa = valueOrNotAvailableIntIfReverted(
+    vTokenContract.try_exchangeRateStored(),
+    'vBEP20 try_exchangeRateStored()',
+  );
+}

--- a/subgraphs/venus/src/operations/updateMarketRates.ts
+++ b/subgraphs/venus/src/operations/updateMarketRates.ts
@@ -1,0 +1,13 @@
+import { Market } from '../../generated/schema';
+import { VToken } from '../../generated/templates/VToken/VToken';
+import { updateMarketBorrowRate } from './updateMarketBorrowRate';
+import { updateMarketExchangeRate } from './updateMarketExchangeRate';
+import { updateMarketSupplyRate } from './updateMarketSupplyRate';
+
+// if an event updated the market reserves, it means we need to update the market rates that depend on it:
+// borrow rate, supply rate and the exchange rate
+export function updateMarketRates(market: Market, vTokenContract: VToken): void {
+  updateMarketBorrowRate(market, vTokenContract);
+  updateMarketSupplyRate(market, vTokenContract);
+  updateMarketExchangeRate(market, vTokenContract);
+}

--- a/subgraphs/venus/src/operations/updateMarketSupplyRate.ts
+++ b/subgraphs/venus/src/operations/updateMarketSupplyRate.ts
@@ -1,0 +1,12 @@
+import { Market } from '../../generated/schema';
+import { VToken } from '../../generated/templates/VToken/VToken';
+import { valueOrNotAvailableIntIfReverted } from '../utilities';
+
+export function updateMarketSupplyRate(market: Market, vTokenContract: VToken): void {
+  // This fails on only the first call to cZRX. It is unclear why, but otherwise it works.
+  // So we handle it like this.
+  market.supplyRateMantissa = valueOrNotAvailableIntIfReverted(
+    vTokenContract.try_supplyRatePerBlock(),
+    'vBEP20 try_supplyRatePerBlock()',
+  );
+}

--- a/subgraphs/venus/src/operations/updateMarketTotalSupplyMantissa.ts
+++ b/subgraphs/venus/src/operations/updateMarketTotalSupplyMantissa.ts
@@ -1,0 +1,10 @@
+import { Market } from '../../generated/schema';
+import { VToken } from '../../generated/templates/VToken/VToken';
+import { exponentToBigInt } from '../utilities/exponentToBigInt';
+
+export function updateMarketTotalSupplyMantissa(market: Market, vTokenContract: VToken): void {
+  market.totalSupplyMantissa = vTokenContract
+    .totalSupply()
+    .times(market.exchangeRateMantissa)
+    .div(exponentToBigInt(18));
+}

--- a/subgraphs/venus/template.yaml
+++ b/subgraphs/venus/template.yaml
@@ -125,6 +125,10 @@ templates:
           handler: handleTransfer
         - event: NewMarketInterestRateModel(address,address)
           handler: handleNewMarketInterestRateModel
+        - event: ReservesAdded(address,uint256,uint256)
+          handler: handleReservesAdded
+        - event: ReservesReduced(address,uint256,uint256)
+          handler: handleReservesReduced
   - name: VTokenUpdatedEvents
     kind: ethereum/contract
     network: {{ network }}

--- a/subgraphs/venus/tests/VToken/events.ts
+++ b/subgraphs/venus/tests/VToken/events.ts
@@ -143,7 +143,7 @@ export const createBorrowEvent = (
   return event;
 };
 
-export const createRepayBorrowEventV1 = (
+export const createRepayBorrowEvent = (
   vTokenAddress: Address,
   payerAddress: Address,
   borrowerAddress: Address,

--- a/subgraphs/venus/tests/VToken/events.ts
+++ b/subgraphs/venus/tests/VToken/events.ts
@@ -14,6 +14,8 @@ import {
   NewReserveFactor as NewReserveFactorEvent,
   Redeem as RedeemEventV1,
   RepayBorrow as RepayBorrowEventV1,
+  ReservesAdded as ReservesAddedEvent,
+  ReservesReduced as ReservesReducedEvent,
   Transfer as TransferEvent,
 } from '../../generated/templates/VToken/VToken';
 import {
@@ -513,6 +515,65 @@ export const createRedeemEventV1 = (
     ethereum.Value.fromUnsignedBigInt(redeemTokens),
   );
   event.parameters.push(redeemTokensParam);
+
+  return event;
+};
+
+export const createReservesAddedEvent = (
+  vTokenAddress: Address,
+  benefactor: Address,
+  addAmount: BigInt,
+  newTotalReserves: BigInt,
+): ReservesAddedEvent => {
+  const event = changetype<ReservesAddedEvent>(newMockEvent());
+  event.address = vTokenAddress;
+  event.parameters = [];
+
+  const addAmountParam = new ethereum.EventParam(
+    'addAmount',
+    ethereum.Value.fromUnsignedBigInt(addAmount),
+  );
+  event.parameters.push(addAmountParam);
+
+  const benefactorParam = new ethereum.EventParam(
+    'benefactor',
+    ethereum.Value.fromAddress(benefactor),
+  );
+  event.parameters.push(benefactorParam);
+
+  const newTotalReservesParam = new ethereum.EventParam(
+    'newTotalReserves',
+    ethereum.Value.fromUnsignedBigInt(newTotalReserves),
+  );
+  event.parameters.push(newTotalReservesParam);
+
+  return event;
+};
+
+export const createReservesReducedEvent = (
+  vTokenAddress: Address,
+  admin: Address,
+  reduceAmount: BigInt,
+  newTotalReserves: BigInt,
+): ReservesReducedEvent => {
+  const event = changetype<ReservesReducedEvent>(newMockEvent());
+  event.address = vTokenAddress;
+  event.parameters = [];
+
+  const reduceAmountParam = new ethereum.EventParam(
+    'reduceAmount',
+    ethereum.Value.fromUnsignedBigInt(reduceAmount),
+  );
+  event.parameters.push(reduceAmountParam);
+
+  const adminParam = new ethereum.EventParam('admin', ethereum.Value.fromAddress(admin));
+  event.parameters.push(adminParam);
+
+  const newTotalReservesParam = new ethereum.EventParam(
+    'newTotalReserves',
+    ethereum.Value.fromUnsignedBigInt(newTotalReserves),
+  );
+  event.parameters.push(newTotalReservesParam);
 
   return event;
 };

--- a/subgraphs/venus/tests/VToken/index.test.ts
+++ b/subgraphs/venus/tests/VToken/index.test.ts
@@ -43,7 +43,7 @@ import {
   createNewReserveFactorEvent,
   createRedeemEvent,
   createRedeemEventV1,
-  createRepayBorrowEventV1,
+  createRepayBorrowEvent,
   createTransferEvent,
 } from './events';
 import { createAccountVTokenBalanceOfMock } from './mocks';
@@ -205,7 +205,7 @@ describe('VToken', () => {
     const balanceOf = BigInt.fromString('9937035970026454');
 
     /** Setup test */
-    const repayBorrowEvent = createRepayBorrowEventV1(
+    const repayBorrowEvent = createRepayBorrowEvent(
       aaaTokenAddress,
       payer,
       borrower,
@@ -579,7 +579,7 @@ describe('VToken', () => {
     assert.fieldEquals('Market', aaaTokenAddress.toHex(), 'borrowerCount', '2');
     assert.fieldEquals('Market', aaaTokenAddress.toHex(), 'borrowerCountAdjusted', '2');
 
-    let repayEvent = createRepayBorrowEventV1(
+    let repayEvent = createRepayBorrowEvent(
       aaaTokenAddress,
       borrower02,
       borrower02,
@@ -592,7 +592,7 @@ describe('VToken', () => {
     assert.fieldEquals('Market', aaaTokenAddress.toHex(), 'borrowerCount', '1');
     assert.fieldEquals('Market', aaaTokenAddress.toHex(), 'borrowerCountAdjusted', '1');
 
-    repayEvent = createRepayBorrowEventV1(
+    repayEvent = createRepayBorrowEvent(
       aaaTokenAddress,
       borrower01,
       borrower01,
@@ -605,7 +605,7 @@ describe('VToken', () => {
     assert.fieldEquals('Market', aaaTokenAddress.toHex(), 'borrowerCount', '1');
     assert.fieldEquals('Market', aaaTokenAddress.toHex(), 'borrowerCountAdjusted', '1');
 
-    repayEvent = createRepayBorrowEventV1(
+    repayEvent = createRepayBorrowEvent(
       aaaTokenAddress,
       borrower01,
       borrower01,

--- a/subgraphs/venus/tests/VToken/index.test.ts
+++ b/subgraphs/venus/tests/VToken/index.test.ts
@@ -282,18 +282,18 @@ describe('VToken', () => {
 
   test('registers accrue interest event', () => {
     /** Constants */
-    const cashPrior = BigInt.fromString('1246205398726345');
+    const cashPrior = BigInt.fromString('5555566666000012345');
     const interestAccumulated = BigInt.fromI32(26454);
-    const borrowIndex = BigInt.fromI32(1);
-    const totalBorrows = BigInt.fromString('62197468301');
+    const newBorrowIndex = BigInt.fromString('400000000000000000000');
+    const newTotalBorrows = BigInt.fromString('4321234234636158123');
 
     /** Setup test */
     const accrueInterestEvent = createAccrueInterestEvent(
       aaaTokenAddress,
       cashPrior,
       interestAccumulated,
-      borrowIndex,
-      totalBorrows,
+      newBorrowIndex,
+      newTotalBorrows,
     );
 
     /** Fire Event */
@@ -306,10 +306,10 @@ describe('VToken', () => {
     assertMarketDocument('accrualBlockNumber', '999');
     assertMarketDocument('blockTimestamp', accrueInterestEvent.block.timestamp.toString());
     assertMarketDocument('exchangeRateMantissa', '365045823500000000000000');
-    assertMarketDocument('borrowIndexMantissa', '300000000000000000000');
+    assertMarketDocument('borrowIndexMantissa', newBorrowIndex.toString());
     assertMarketDocument('reservesMantissa', '5128924555022289393');
-    assertMarketDocument('totalBorrowsMantissa', '2641234234636158123');
-    assertMarketDocument('cashMantissa', '1418171344423412457');
+    assertMarketDocument('totalBorrowsMantissa', newTotalBorrows.toString());
+    assertMarketDocument('cashMantissa', cashPrior.toString());
     assertMarketDocument('borrowRateMantissa', '12678493');
     assertMarketDocument('supplyRateMantissa', '12678493');
   });

--- a/subgraphs/venus/tests/VToken/index.test.ts
+++ b/subgraphs/venus/tests/VToken/index.test.ts
@@ -26,6 +26,8 @@ import {
   handleRedeem,
   handleRedeemV1,
   handleRepayBorrow,
+  handleReservesAdded,
+  handleReservesReduced,
   handleTransfer,
 } from '../../src/mappings/vToken';
 import { getMarket } from '../../src/operations/get';
@@ -44,6 +46,8 @@ import {
   createRedeemEvent,
   createRedeemEventV1,
   createRepayBorrowEvent,
+  createReservesAddedEvent,
+  createReservesReducedEvent,
   createTransferEvent,
 } from './events';
 import { createAccountVTokenBalanceOfMock } from './mocks';
@@ -617,5 +621,47 @@ describe('VToken', () => {
     handleRepayBorrow(repayEvent);
     assert.fieldEquals('Market', aaaTokenAddress.toHex(), 'borrowerCount', '1');
     assert.fieldEquals('Market', aaaTokenAddress.toHex(), 'borrowerCountAdjusted', '0');
+  });
+
+  test('registers reserves added event', () => {
+    const benefactor = Address.fromString('0x0000000000000000000000000000000000000111');
+    const addAmount = BigInt.fromString('123456789000000');
+    const newTotalReserves = BigInt.fromString('123456789000000');
+    const newReservesAddedEvent = createReservesAddedEvent(
+      aaaTokenAddress,
+      benefactor,
+      addAmount,
+      newTotalReserves,
+    );
+
+    handleReservesAdded(newReservesAddedEvent);
+    assert.fieldEquals('Market', aaaTokenAddress.toHex(), 'id', aaaTokenAddress.toHexString());
+    assert.fieldEquals(
+      'Market',
+      aaaTokenAddress.toHex(),
+      'reservesMantissa',
+      newTotalReserves.toString(),
+    );
+  });
+
+  test('registers reserves reduced event', () => {
+    const admin = Address.fromString('0x0000000000000000000000000000000000000111');
+    const reduceAmount = BigInt.fromString('123456789000000');
+    const newTotalReserves = BigInt.fromString('0');
+    const newReservesReducedEvent = createReservesReducedEvent(
+      aaaTokenAddress,
+      admin,
+      reduceAmount,
+      newTotalReserves,
+    );
+
+    handleReservesReduced(newReservesReducedEvent);
+    assert.fieldEquals('Market', aaaTokenAddress.toHex(), 'id', aaaTokenAddress.toHexString());
+    assert.fieldEquals(
+      'Market',
+      aaaTokenAddress.toHex(),
+      'reservesMantissa',
+      newTotalReserves.toString(),
+    );
   });
 });


### PR DESCRIPTION
### Changes

- `getOrCreate` market now only makes RPC calls when creating a market, getting a market only returns the stored data
- Added update operations for specific market fields that require RPC calls and/or calculation logic
- Reworked VToken events:
  - accrueInterest now updates the market cash value from the corresponding event param. Makes RPC calls to retrieve the total reserves and the market rates
  - Mint and redeem events update the total supply, cash and market rates.
  - Borrow and repay events now update the market total borrows with the corresponding event param. Also updates the cash value and rates.