### PR TITLE
fix: Mint and Redeem account vtoken balances

### DIFF
--- a/subgraphs/isolated-pools/src/mappings/vToken.ts
+++ b/subgraphs/isolated-pools/src/mappings/vToken.ts
@@ -45,8 +45,6 @@ import {
  *    AccrueInterest is emitted before Mint
  *    Transfer event is emitted after Mint if successful
  *    No need to updateMarket(), handleAccrueInterest() ALWAYS runs before this
- *    No need to updateCommonVTokenStats, handleTransfer() will
- *    No need to update vTokenBalance, handleTransfer() will
  */
 export function handleMint(event: Mint): void {
   const vTokenAddress = event.address;
@@ -80,8 +78,6 @@ export function handleMint(event: Mint): void {
  *  Notes
  *    Transfer event will always get emitted with this
  *    No need to updateMarket(), handleAccrueInterest() ALWAYS runs before this
- *    No need to updateCommonVTokenStats, handleTransfer() will
- *    No need to update vTokenBalance, handleTransfer() will
  */
 export function handleRedeem(event: Redeem): void {
   const vTokenAddress = event.address;

--- a/subgraphs/venus/package.json
+++ b/subgraphs/venus/package.json
@@ -18,6 +18,7 @@
     "deploy:docker": "yarn prepare:docker && yarn graph deploy venusprotocol/venus-subgraph --ipfs http://ipfs:5001 --node http://graph-node:8020/ --version-label ci",
     "deploy:chapel": "yarn prepare:chapel && graph deploy venusprotocol/venus-subgraph-chapel --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy:bsc": "yarn prepare:bsc && graph deploy venusprotocol/venus-subgraph --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
+    "deploy:bsc-next": "yarn prepare:bsc && graph deploy venusprotocol/venus-core-pool-next --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "prepare:docker": "NETWORK=docker yarn ts-node config/index.ts",
     "prepare:chapel": "NETWORK=chapel yarn ts-node config/index.ts",
     "prepare:bsc": "NETWORK=bsc yarn ts-node config/index.ts",
@@ -27,6 +28,7 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.67.1",
     "@venusprotocol/venus-protocol": "5.2.0",
-    "@venusprotocol/venus-protocol-orig-events": "npm:@venusprotocol/venus-protocol@2.2.1"
+    "@venusprotocol/venus-protocol-orig-events": "npm:@venusprotocol/venus-protocol@2.2.1",
+    "ts-node": "^10.9.2"
   }
 }

--- a/subgraphs/venus/package.json
+++ b/subgraphs/venus/package.json
@@ -10,21 +10,22 @@
     "generated"
   ],
   "scripts": {
-    "codegen": "npx graph codegen",
-    "create:docker": "npx graph create venusprotocol/venus-subgraph  --node http://graph-node:8020/",
-    "build:docker": "npx graph build --ipfs http://ipfs:5001",
+    "codegen": "yarn graph codegen",
+    "create:docker": "yarn graph create venusprotocol/venus-subgraph  --node http://graph-node:8020/",
+    "build:docker": "yarn graph build --ipfs http://ipfs:5001",
     "build:bsc": "graph build --ipfs https://api.thegraph.com/ipfs/ ",
     "deploy:integration": "graph deploy venusprotocol/venus-subgraph  --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020/",
-    "deploy:docker": "yarn prepare:docker && npx graph deploy venusprotocol/venus-subgraph --ipfs http://ipfs:5001 --node http://graph-node:8020/ --version-label ci",
+    "deploy:docker": "yarn prepare:docker && yarn graph deploy venusprotocol/venus-subgraph --ipfs http://ipfs:5001 --node http://graph-node:8020/ --version-label ci",
     "deploy:chapel": "yarn prepare:chapel && graph deploy venusprotocol/venus-subgraph-chapel --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy:bsc": "yarn prepare:bsc && graph deploy venusprotocol/venus-subgraph --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
-    "prepare:docker": "NETWORK=docker npx ts-node config/index.ts",
-    "prepare:chapel": "NETWORK=chapel npx ts-node config/index.ts",
-    "prepare:bsc": "NETWORK=bsc npx ts-node config/index.ts",
+    "prepare:docker": "NETWORK=docker yarn ts-node config/index.ts",
+    "prepare:chapel": "NETWORK=chapel yarn ts-node config/index.ts",
+    "prepare:bsc": "NETWORK=bsc yarn ts-node config/index.ts",
     "test": "graph test",
     "test:integration": "true"
   },
   "dependencies": {
+    "@graphprotocol/graph-cli": "^0.67.1",
     "@venusprotocol/venus-protocol": "5.2.0",
     "@venusprotocol/venus-protocol-orig-events": "npm:@venusprotocol/venus-protocol@2.2.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15930,6 +15930,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vai-subgraph@workspace:subgraphs/vai"
   dependencies:
+    "@graphprotocol/graph-cli": ^0.67.1
+    "@venusprotocol/venus-protocol": 5.2.0
     apollo-fetch: ^0.7.0
     urql: ^3.0.3
     venus-subgraph-utils: 0.0.0
@@ -16002,6 +16004,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "venus-subgraph@workspace:subgraphs/venus"
   dependencies:
+    "@graphprotocol/graph-cli": ^0.67.1
     "@venusprotocol/venus-protocol": 5.2.0
     "@venusprotocol/venus-protocol-orig-events": "npm:@venusprotocol/venus-protocol@2.2.1"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -15280,7 +15280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-node@npm:^10.9.1":
+"ts-node@npm:^10.9.1, ts-node@npm:^10.9.2":
   version: 10.9.2
   resolution: "ts-node@npm:10.9.2"
   dependencies:
@@ -16007,6 +16007,7 @@ __metadata:
     "@graphprotocol/graph-cli": ^0.67.1
     "@venusprotocol/venus-protocol": 5.2.0
     "@venusprotocol/venus-protocol-orig-events": "npm:@venusprotocol/venus-protocol@2.2.1"
+    ts-node: ^10.9.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
For Mint and reedeem it was assumed that transfer would handle but transfer also assumed mint and redeem handled the logic. This PR adds the logic for updating the accountVToken to their respective events.