### PR TITLE
refactor: remove totalUnderlyingSuppliedMantissa from account

### DIFF
--- a/subgraphs/isolated-pools/tests/integration/pool.ts
+++ b/subgraphs/isolated-pools/tests/integration/pool.ts
@@ -137,10 +137,6 @@ describe('Pools', function () {
       const expectedMarketId = account?.tokens[idx].id.split('-')[0];
       expect(avt.market.id).to.equal(expectedMarketId);
       expect(avt.account.id).to.equal(account?.id);
-      // check accountVTokenTransaction
-      expect(avt.transactions.length).to.equal(1);
-      expect(avt.transactions[0].block).to.not.be.equal(0);
-      expect(avt.transactions[0].timestamp).to.not.be.equal(0);
 
       expect(avt.enteredMarket).to.equal(true);
       expect(avt.accountSupplyBalanceMantissa).to.equal('0');

--- a/subgraphs/venus/schema.graphql
+++ b/subgraphs/venus/schema.graphql
@@ -117,8 +117,6 @@ type AccountVToken @entity {
 
     "VToken balance of the user"
     vTokenBalanceMantissa: BigInt!
-    "Total amount of underlying supplied"
-    totalUnderlyingSuppliedMantissa: BigInt!
     "Total amount of underlying redeemed"
     totalUnderlyingRedeemedMantissa: BigInt!
     "The value of the borrow index upon users last interaction"

--- a/subgraphs/venus/src/mappings/vToken.ts
+++ b/subgraphs/venus/src/mappings/vToken.ts
@@ -40,7 +40,6 @@ import { updateMarketCashMantissa } from '../operations/updateMarketCashMantissa
 import { updateMarketRates } from '../operations/updateMarketRates';
 import { updateMarketTotalSupplyMantissa } from '../operations/updateMarketTotalSupplyMantissa';
 import { getUnderlyingPrice } from '../utilities';
-import { exponentToBigInt } from '../utilities/exponentToBigInt';
 
 /* Account supplies assets into market and receives vTokens in exchange
  *
@@ -77,8 +76,6 @@ export function handleMint(event: Mint): void {
   accountVToken.vTokenBalanceMantissa = accountVToken.vTokenBalanceMantissa.plus(
     event.params.mintTokens,
   );
-  accountVToken.totalUnderlyingSuppliedMantissa =
-    accountVToken.totalUnderlyingSuppliedMantissa.plus(event.params.mintAmount);
   accountVToken.save();
 }
 
@@ -106,8 +103,6 @@ export function handleMintBehalf(event: MintBehalf): void {
   accountVToken.vTokenBalanceMantissa = accountVToken.vTokenBalanceMantissa.minus(
     event.params.mintTokens,
   );
-  accountVToken.totalUnderlyingSuppliedMantissa =
-    accountVToken.totalUnderlyingSuppliedMantissa.plus(event.params.mintAmount);
   accountVToken.save();
 }
 
@@ -146,8 +141,6 @@ export function handleRedeem(event: Redeem): void {
   accountVToken.vTokenBalanceMantissa = accountVToken.vTokenBalanceMantissa.minus(
     event.params.redeemTokens,
   );
-  accountVToken.totalUnderlyingSuppliedMantissa =
-    accountVToken.totalUnderlyingSuppliedMantissa.minus(event.params.redeemAmount);
   accountVToken.totalUnderlyingRedeemedMantissa =
     accountVToken.totalUnderlyingRedeemedMantissa.plus(event.params.redeemAmount);
   accountVToken.save();
@@ -286,10 +279,6 @@ export function handleTransfer(event: Transfer): void {
   // with normal transfers, since mint, redeem, and seize transfers will already run updateMarket()
   let market = getOrCreateMarket(event.address, event);
 
-  const amountUnderlying = market.exchangeRateMantissa
-    .times(event.params.amount)
-    .div(exponentToBigInt(18));
-
   let accountFromAddress = event.params.from;
   let accountToAddress = event.params.to;
   // Checking if the tx is FROM the vToken contract or null (i.e. this will not run when minting)
@@ -310,8 +299,6 @@ export function handleTransfer(event: Transfer): void {
     accountFromVToken.vTokenBalanceMantissa = accountFromVToken.vTokenBalanceMantissa.minus(
       event.params.amount,
     );
-    accountFromVToken.totalUnderlyingSuppliedMantissa =
-      accountFromVToken.totalUnderlyingSuppliedMantissa.minus(amountUnderlying);
     accountFromVToken.save();
 
     getOrCreateAccountVTokenTransaction(accountFromVToken.id, event);
@@ -321,8 +308,6 @@ export function handleTransfer(event: Transfer): void {
     accountToVToken.vTokenBalanceMantissa = accountToVToken.vTokenBalanceMantissa.plus(
       event.params.amount,
     );
-    accountToVToken.totalUnderlyingSuppliedMantissa =
-      accountToVToken.totalUnderlyingSuppliedMantissa.plus(amountUnderlying);
     accountToVToken.save();
 
     getOrCreateAccountVTokenTransaction(accountToVToken.id, event);

--- a/subgraphs/venus/src/operations/getOrCreate.ts
+++ b/subgraphs/venus/src/operations/getOrCreate.ts
@@ -134,7 +134,6 @@ export function getOrCreateAccountVToken(
     const vTokenContract = VToken.bind(Address.fromString(marketId));
     accountVToken.vTokenBalanceMantissa = vTokenContract.balanceOf(Address.fromString(accountId));
 
-    accountVToken.totalUnderlyingSuppliedMantissa = zeroBigInt32;
     accountVToken.totalUnderlyingRedeemedMantissa = zeroBigInt32;
     accountVToken.accountBorrowIndexMantissa = zeroBigInt32;
     accountVToken.totalUnderlyingBorrowedMantissa = zeroBigInt32;

--- a/subgraphs/venus/tests/VToken/index.test.ts
+++ b/subgraphs/venus/tests/VToken/index.test.ts
@@ -126,13 +126,6 @@ describe('VToken', () => {
     assert.fieldEquals(
       'AccountVToken',
       accountVTokenId,
-      'totalUnderlyingSuppliedMantissa',
-      actualMintAmount.toString(),
-    );
-
-    assert.fieldEquals(
-      'AccountVToken',
-      accountVTokenId,
       'vTokenBalanceMantissa',
       mintTokens.toString(),
     );
@@ -155,13 +148,6 @@ describe('VToken', () => {
 
     const accountVTokenId = getAccountVTokenId(aaaTokenAddress, redeemer);
 
-    assert.fieldEquals(
-      'AccountVToken',
-      accountVTokenId,
-      'totalUnderlyingSuppliedMantissa',
-      mintEvent.params.mintAmount.toString(),
-    );
-
     const redeemEvent = createRedeemEvent(
       aaaTokenAddress,
       redeemer,
@@ -182,8 +168,6 @@ describe('VToken', () => {
     );
 
     assert.fieldEquals('AccountVToken', accountVTokenId, 'vTokenBalanceMantissa', '0');
-
-    assert.fieldEquals('AccountVToken', accountVTokenId, 'totalUnderlyingSuppliedMantissa', '0');
 
     assert.fieldEquals(
       'AccountVToken',
@@ -440,18 +424,6 @@ describe('VToken', () => {
       'vTokenBalanceMantissa',
       mintTokens.toString(),
     );
-    const market = getMarket(aaaTokenAddress)!;
-
-    const amountUnderlying = market.exchangeRateMantissa
-      .times(amount)
-      .div(BigInt.fromI64(1000000000000000000));
-
-    assert.fieldEquals(
-      'AccountVToken',
-      accountVTokenId,
-      'totalUnderlyingSuppliedMantissa',
-      actualMintAmount.toString(),
-    );
 
     /** Fire Event */
     handleTransfer(transferEvent);
@@ -462,13 +434,6 @@ describe('VToken', () => {
       accountVTokenId,
       'vTokenBalanceMantissa',
       mintTokens.minus(amount).toString(),
-    );
-
-    assert.fieldEquals(
-      'AccountVToken',
-      accountVTokenId,
-      'totalUnderlyingSuppliedMantissa',
-      actualMintAmount.minus(amountUnderlying).toString(),
     );
   });
 
@@ -513,18 +478,6 @@ describe('VToken', () => {
       accountVTokenId,
       'vTokenBalanceMantissa',
       amount.plus(balanceOf).toString(),
-    );
-
-    const market = getMarket(aaaTokenAddress)!;
-    const amountUnderlying = market.exchangeRateMantissa
-      .times(amount)
-      .div(BigInt.fromI64(1000000000000000000));
-
-    assert.fieldEquals(
-      'AccountVToken',
-      accountVTokenId,
-      'totalUnderlyingSuppliedMantissa',
-      amountUnderlying.toString(),
     );
   });
 


### PR DESCRIPTION
To avoid confusion we are removing total underlying supplied from the account entity.
Instead consumers should calculate this using the exchange rate and vToken balance.