### PR TITLE
chore: add published versions of subgraphs

### DIFF
--- a/subgraphs/cross-chain-governance/package.json
+++ b/subgraphs/cross-chain-governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "venus-cross-chain-governance-subgraph",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/VenusProtocol/subgraphs",

--- a/subgraphs/etherfi-promo/package.json
+++ b/subgraphs/etherfi-promo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etherfi-promo-subgraph",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/VenusProtocol/subgraphs",

--- a/subgraphs/isolated-pools/package.json
+++ b/subgraphs/isolated-pools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolated-pools-subgraph",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/VenusProtocol/subgraphs",

--- a/subgraphs/protocol-reserve/package.json
+++ b/subgraphs/protocol-reserve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-reserve-subgraph",
-  "version": "0.0.0",
+  "version": "0.0.5",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/VenusProtocol/subgraphs",

--- a/subgraphs/venus-governance/package.json
+++ b/subgraphs/venus-governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "venus-governance-subgraph",
-  "version": "0.0.0",
+  "version": "0.0.10",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/VenusProtocol/subgraphs",

--- a/subgraphs/venus/package.json
+++ b/subgraphs/venus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "venus-subgraph",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/VenusProtocol/subgraphs",


### PR DESCRIPTION
Add published versions of subgraphs. 
Some subgraphs have mismatched versions on different environments. To resolve this, the next version bump will get deployed to all networks.