### PR TITLE
fix: also associate when execture event received

### DIFF
--- a/subgraphs/venus-governance/src/mappings/omnichainProposalSender.ts
+++ b/subgraphs/venus-governance/src/mappings/omnichainProposalSender.ts
@@ -29,6 +29,7 @@ export function handleSetTrustedRemoteAddress(event: SetTrustedRemoteAddress): v
 }
 
 export function handleExecuteRemoteProposal(event: ExecuteRemoteProposal): void {
+  associateSourceAndRemoteProposals(event);
   const transaction = getOrCreateTransaction(event);
   const remoteProposalStateTransaction = getRemoteProposalStateTransaction(event.params.proposalId);
   remoteProposalStateTransaction.executed = transaction.id;


### PR DESCRIPTION
Associate remote proposals when executing and storing payload