### PR TITLE
refactor: allow trusted remote to be null

### DIFF
--- a/subgraphs/venus-governance/config/index.ts
+++ b/subgraphs/venus-governance/config/index.ts
@@ -52,7 +52,8 @@ const main = () => {
       xvsVaultAddress: bscTestnetCoreDeployments.addresses.XVSVaultProxy,
       xvsVaultStartBlock: '13937802',
       xvsVaultPid: '1',
-      omnichainProposalSenderAddress: '0xCfD34AEB46b1CB4779c945854d405E91D27A1899',
+      omnichainProposalSenderAddress:
+        bscTestnetGovernanceDeployments.addresses.OmnichainProposalSender,
       omnichainProposalSenderStartBlock: '40979674',
     },
     bsc: {

--- a/subgraphs/venus-governance/schema.graphql
+++ b/subgraphs/venus-governance/schema.graphql
@@ -256,7 +256,7 @@ type RemoteProposal @entity {
   proposalId: BigInt
 
   "Remote ChainId where the proposal was sent"
-  trustedRemote: TrustedRemote!
+  trustedRemote: TrustedRemote
 
   "Targets data for the change"
   targets: [Bytes!]


### PR DESCRIPTION
If a proposal is created with an invalid layerzero id we won't be able to save a related trusted remote so the value will be null.

This modifies the schema to support this edge case