### PR TITLE
feat: save untrusted remote for completion and transparency

### DIFF
--- a/subgraphs/venus-governance/schema.graphql
+++ b/subgraphs/venus-governance/schema.graphql
@@ -256,7 +256,7 @@ type RemoteProposal @entity {
   proposalId: BigInt
 
   "Remote ChainId where the proposal was sent"
-  trustedRemote: TrustedRemote
+  trustedRemote: TrustedRemote!
 
   "Targets data for the change"
   targets: [Bytes!]


### PR DESCRIPTION
Record Trusted Remote will null address and active = false if an invalid trusted remote is included on a proposal