### PR TITLE
chore: bump spec and api versions

### DIFF
--- a/subgraphs/etherfi-promo/template.yaml
+++ b/subgraphs/etherfi-promo/template.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.4
+specVersion: 1.2.0
 description: Venus is an open-source protocol for algorithmic, efficient Money Markets on the BSC blockchain.
 repository: https://github.com/VenusProtocol/subgraphs
 schema:

--- a/subgraphs/isolated-pools/template.yaml
+++ b/subgraphs/isolated-pools/template.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.2
+specVersion: 1.2.0
 description: Venus is an open-source protocol for algorithmic, efficient Money Markets.
 repository: https://github.com/VenusProtocol/subgraphs
 schema:
@@ -13,7 +13,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/poolRegistry.ts
       entities:
@@ -50,7 +50,7 @@ templates:
       abi: Comptroller
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/pool.ts
       entities:
@@ -106,7 +106,7 @@ templates:
       abi: VToken
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/vToken.ts
       entities:
@@ -158,7 +158,7 @@ templates:
       abi: RewardsDistributor
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/rewardsDistributor.ts
       entities:

--- a/subgraphs/protocol-reserve/template-eth.yaml
+++ b/subgraphs/protocol-reserve/template-eth.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.4
+specVersion: 1.2.0
 description: Venus Protocol Reserve manages income generated from Venus money markets.
 repository: https://github.com/VenusProtocol/subgraphs
 schema:
@@ -13,7 +13,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/converterNetwork.ts
       entities:
@@ -38,7 +38,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/tokenConverter.ts
       entities:
@@ -72,7 +72,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/tokenConverter.ts
       entities:
@@ -106,7 +106,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/tokenConverter.ts
       entities:
@@ -140,7 +140,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/tokenConverter.ts
       entities:
@@ -174,7 +174,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/tokenConverter.ts
       entities:

--- a/subgraphs/protocol-reserve/template.yaml
+++ b/subgraphs/protocol-reserve/template.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.4
+specVersion: 1.2.0
 description: Venus Protocol Reserve manages income generated from Venus money markets.
 repository: https://github.com/VenusProtocol/subgraphs
 schema:
@@ -13,7 +13,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/converterNetwork.ts
       entities:
@@ -38,7 +38,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/tokenConverter.ts
       entities:
@@ -72,7 +72,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/tokenConverter.ts
       entities:
@@ -106,7 +106,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/tokenConverter.ts
       entities:
@@ -138,7 +138,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/tokenConverter.ts
       entities:
@@ -172,7 +172,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/tokenConverter.ts
       entities:
@@ -206,7 +206,7 @@ dataSources:
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       file: ./src/mappings/tokenConverter.ts
       entities:


### PR DESCRIPTION
bump spec version to 1.2.0 and api versions to 0.0.9 on all subgraphs