### PR TITLE
fix: update total delegate count, set balance to zero instead of deleting

### DIFF
--- a/subgraphs/venus-governance/src/operations/getOrCreate.ts
+++ b/subgraphs/venus-governance/src/operations/getOrCreate.ts
@@ -7,8 +7,7 @@ import {
   Transaction,
   TrustedRemote,
 } from '../../generated/schema';
-import { BIGINT_ONE, BIGINT_ZERO } from '../constants';
-import { nullAddress } from '../constants/addresses';
+import { BIGINT_ZERO } from '../constants';
 import { getRemoteProposalId } from '../utilities/ids';
 import {
   getDelegateId,
@@ -16,7 +15,6 @@ import {
   getRemoteProposalStateTransactionId,
   getTrustedRemoteId,
 } from '../utilities/ids';
-import { getGovernanceEntity } from './get';
 
 export class GetOrCreateDelegateReturn {
   entity: Delegate;
@@ -32,12 +30,6 @@ export const getOrCreateDelegate = (address: Address): GetOrCreateDelegateReturn
     delegate.stakedXvsMantissa = BIGINT_ZERO;
     delegate.totalVotesMantissa = BIGINT_ZERO;
     delegate.delegateCount = 0;
-
-    if (id != nullAddress) {
-      const governance = getGovernanceEntity();
-      governance.totalDelegates = governance.totalDelegates.plus(BIGINT_ONE);
-      governance.save();
-    }
 
     delegate.save();
     created = true;

--- a/subgraphs/venus-governance/tests/integration/xvsVault.ts
+++ b/subgraphs/venus-governance/tests/integration/xvsVault.ts
@@ -190,7 +190,7 @@ describe('XVS Vault and Delegation', function () {
       expect(delegate2.totalVotesMantissa).to.equal('0');
     });
 
-    it('should remove delegate when xvs is withdrawn', async function () {
+    it('should update delegate when xvs is withdrawn', async function () {
       const [_, user1, user2] = signers;
 
       await xvsVault.connect(user1).requestWithdrawal(xvs.address, 0, amount.toFixed());
@@ -201,7 +201,8 @@ describe('XVS Vault and Delegation', function () {
         data: { delegate: delegate1 },
       } = await subgraphClient.getDelegateById(user1.address.toLowerCase());
 
-      expect(delegate1).to.equal(null);
+      expect(delegate1.stakedXvsMantissa).to.equal('0');
+      expect(delegate1.totalVotesMantissa).to.equal('0');
 
       const {
         data: { delegate: delegate2 },

--- a/subgraphs/venus-governance/tests/unit/XVSVault/index.test.ts
+++ b/subgraphs/venus-governance/tests/unit/XVSVault/index.test.ts
@@ -76,7 +76,7 @@ describe('XVS Vault', () => {
     assert.fieldEquals('Delegate', user.toHex(), 'stakedXvsMantissa', '800000000000000000');
   });
 
-  test('removes delegate after withdrawing everything', () => {
+  test('updates delegate after withdrawing everything', () => {
     const user = Address.fromString('0x0000000000000000000000000000000000000404');
     const amount = '800000000000000000';
     /** run handler */
@@ -89,8 +89,8 @@ describe('XVS Vault', () => {
 
     handleRequestedWithdrawal(withdrawRequestedEvent);
 
-    // Expect delegate to have been removed
-    assert.entityCount('Delegate', 1);
+    assert.entityCount('Delegate', 2);
+    assert.fieldEquals('Delegate', user.toHex(), 'stakedXvsMantissa', '0');
   });
 
   test('delegate changed', () => {


### PR DESCRIPTION
- Set voting power to zero instead of deleting
- Update delegate count in deposit and withdraw events