### PR TITLE
ci: skip deployments on non release branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,6 +148,11 @@ jobs:
   release-cross-chain-governance:
     runs-on: ubuntu-20.04
     needs: [unit-test, lint]
+    if:
+      contains('
+        refs/heads/main
+        refs/heads/testnet
+      ', github.ref)
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -182,6 +187,11 @@ jobs:
   release-etherfi-promo:
     runs-on: ubuntu-20.04
     needs: [unit-test, lint, release-cross-chain-governance]
+    if:
+      contains('
+        refs/heads/main
+        refs/heads/testnet
+      ', github.ref)
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -216,6 +226,11 @@ jobs:
   release-isolated-pools:
     runs-on: ubuntu-20.04
     needs: [unit-test, lint, integration-test-isolated-pools, release-etherfi-promo]
+    if:
+      contains('
+        refs/heads/main
+        refs/heads/testnet
+      ', github.ref)
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -250,6 +265,11 @@ jobs:
   release-protocol-reserve:
     runs-on: ubuntu-20.04
     needs: [unit-test, lint, release-isolated-pools]
+    if:
+      contains('
+        refs/heads/main
+        refs/heads/testnet
+      ', github.ref)
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -284,6 +304,11 @@ jobs:
   release-core-pool:
     runs-on: ubuntu-20.04
     needs: [unit-test, lint, integration-test-core-pool, release-protocol-reserve]
+    if:
+      contains('
+        refs/heads/main
+        refs/heads/testnet
+      ', github.ref)
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -318,6 +343,11 @@ jobs:
   release-governance:
     runs-on: ubuntu-20.04
     needs: [unit-test, lint, integration-test-governance, release-core-pool]
+    if:
+      contains('
+        refs/heads/main
+        refs/heads/testnet
+      ', github.ref)
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Semantic release is only configured to deploy on testnet and main but we can speed up getting green PRs by ignoring deployments all together on any branch but those two